### PR TITLE
build(deps): upgrade @actions/core to 1.2.6 to fix failure

### DIFF
--- a/buildSrc/src/main/kotlin/net/kautler/Versions.kt
+++ b/buildSrc/src/main/kotlin/net/kautler/Versions.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependencyExtension
 val versions = mapOf(
         // project dependencies
         "@actions/cache" to "1.0.1",
-        "@actions/core" to "1.2.4",
+        "@actions/core" to "1.2.6",
         "@actions/exec" to "1.0.4",
         "@actions/http-client" to "1.0.8",
         "@actions/io" to "1.0.2",


### PR DESCRIPTION
As of yesterday (2020-11-16), [GitHub Actions does not allow using `add-path` in Actions](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/). [Here](https://github.com/malept/cross-spawn-windows-exe/pull/5/checks?check_run_id=1413242180#step:3:22) is an example of an action using `setup-wsl` that fails.

I think I've traced it to here:

https://github.com/Vampire/setup-wsl/blob/60cd0fbf475e9a29b60142debaadc7ac58420302/src/main/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt#L314

Per [a blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), upgrading `@actions/core` to at least 1.2.6 should fix this.

Please let me know if there's anything else I need to do here to get the fix working (or feel free to edit the branch yourself).