### PR TITLE
[DNM] Update `installerFile` for Ubtunu 20.04

### DIFF
--- a/src/main/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/main/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -34,7 +34,7 @@ val distributions = listOf(
         OpenSuseLeap15_2,
         Ubuntu1604,
         Ubuntu1804,
-        Ubuntu2004
+        Ubuntu
 ).map { it.id to it }.toMap()
 
 sealed class Distribution(
@@ -170,7 +170,7 @@ abstract class AptGetBasedDistribution : Distribution {
 }
 
 object Ubuntu2004 : AptGetBasedDistribution(
-        id = "Ubuntu-20.04",
+        id = "Ubuntu",
         distributionName = "Ubuntu",
         version = SemVer("20.4.0", jsObject<Options>()),
         downloadUrl = URL("https://aka.ms/wslubuntu2004"),

--- a/src/main/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/main/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -174,7 +174,7 @@ object Ubuntu2004 : AptGetBasedDistribution(
         distributionName = "Ubuntu",
         version = SemVer("20.4.0", jsObject<Options>()),
         downloadUrl = URL("https://aka.ms/wslubuntu2004"),
-        installerFile = "ubuntu2004.exe"
+        installerFile = "ubuntu.exe"
 )
 
 object Ubuntu1804 : AptGetBasedDistribution(


### PR DESCRIPTION
Fixes #17 

I can't find any information on when/why this change was made so I also don't know if it will be reverted, but for now it seems like this could possibly be a fix for #17.

---

## Update: do not merge, read on

This naïve executable name fix won't work if `set-as-default` is `true`, because it turns out the distribution name in WSL is now `Ubuntu` instead of `Ubuntu-20.04`, and the code for setting the default uses the "ID" of the distro as defined in the action, when setting default.

So you could use https://github.com/Vampire/setup-wsl/pull/18/commits/274c35ffc50d77409d9137b3dabab8e853ae6629 with `set-as-default: false`, but then `wsl-bash` will not be set up correctly and you'd be on your own to run WSL commands.

In https://github.com/Vampire/setup-wsl/pull/18/commits/2eec6297d1f3b14d10077b4c65df4c4a23d2d066 I changed the ID to `Ubuntu` so that the action parameter value will match the distribution install name, and this solves the `set-as-default` problem, but it is a breaking change in that you can no longer use `Ubuntu-20.04` as the requested distro, instead you would need to request `Ubuntu`, which will actually be `20.04`.

I also cannot get any of this to work with `use-cache: true`; I can't tell if the reason is because my current cache is poisoned from previous runs or if there's something about these modifications that have broken cache support. Either way, I think that needs to be addressed, because even if it's just the cache in my jobs, I seemingly have no way to fix the state of the cache.

So in short, this fix is not great, and I think there needs to be additional code changes that do one or more of the following:
- after extracting the AppX bundle, read the manifest inside, which will point to the correct .exe name
- decouple the action's distribution input name from the installed distro name
- possibly read the installed distro name from the manifest (I could not confirm that it's specified there definitively, but I think so)
- ensure the cache works, and that a cache in a bad state can be fixed (perhaps something as simple as: if a cached install fails, fall back to re-downloading, and if that's successful, update the cache again)

Unfortunately I'm not in a position to make the above changes.

---

## For anyone looking for a temporary solution

You may use `briantist/setup-wsl@v1-patch-1` to use the patch, if so:
- you must use `Ubuntu` as the distribution name when you want `Ubuntu-20.04`
- you may need to set `use-cache: false` (if you get it working with `use-cache: true` I would like to know)
- **I make no guarantees about that patch whatsoever and I do not think it will or should be merged as-is.** I may change it or mess around it for my own purposes at any time. If you're worried about that, recommend forking and keeping your own copy.
- **Note:** the branch referenced above is _not_ the same branch as this PR, because releases for this action produce a build dir which is what actually gets used, so I needed to branch off a release and monkeypatch that build output, it's not pretty, but oh well.