### PR TITLE
Update GitHub actions typing to v2

### DIFF
--- a/.github/workflows/check-action-typing.main.kts
+++ b/.github/workflows/check-action-typing.main.kts
@@ -24,7 +24,7 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.2.0")
 
 @file:DependsOn("actions:checkout:v4")
-@file:DependsOn("typesafegithub:github-actions-typing:v1")
+@file:DependsOn("typesafegithub:github-actions-typing:v2")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.typesafegithub.GithubActionsTyping

--- a/.github/workflows/check-action-typing.yaml
+++ b/.github/workflows/check-action-typing.yaml
@@ -51,4 +51,4 @@ jobs:
       uses: 'actions/checkout@v4'
     - id: 'step-2'
       name: 'Check Action Typing'
-      uses: 'typesafegithub/github-actions-typing@v1'
+      uses: 'typesafegithub/github-actions-typing@v2'


### PR DESCRIPTION
Shouldn't make a big difference feature-wise, it's for the sake of using latest and greatest.