### PR TITLE
feat: Add versioned distributions, replace non-versioned Alpine and Debian with wsl --import

### DIFF
--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -66,6 +66,48 @@ val environments = listOf(
     "windows-latest"
 )
 
+val alpine323 = Distribution(
+    wslId = "Alpine-3.23",
+    matchPattern = "*Alpine*3.23*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
+val alpine322 = Distribution(
+    wslId = "Alpine-3.22",
+    matchPattern = "*Alpine*3.22*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
+val alpine321 = Distribution(
+    wslId = "Alpine-3.21",
+    matchPattern = "*Alpine*3.21*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
+val alpine320 = Distribution(
+    wslId = "Alpine-3.20",
+    matchPattern = "*Alpine*3.20*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
+val alpine319 = Distribution(
+    wslId = "Alpine-3.19",
+    matchPattern = "*Alpine*3.19*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
+val alpine318 = Distribution(
+    wslId = "Alpine-3.18",
+    matchPattern = "*Alpine*3.18*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
 val alpine317 = Distribution(
     wslId = "Alpine",
     userId = "Alpine-3.17",
@@ -82,6 +124,12 @@ val alpine = Distribution(
 )
 
 val alpineDistributions = listOf(
+    alpine323,
+    alpine322,
+    alpine321,
+    alpine320,
+    alpine319,
+    alpine318,
     alpine317,
     alpine
 )

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -134,6 +134,12 @@ val alpineDistributions = listOf(
     alpine
 )
 
+val debian13 = Distribution(
+    wslId = "Debian-13",
+    matchPattern = "*Debian*13*",
+    defaultAbsentTool = "dos2unix"
+)
+
 val debian12 = Distribution(
     wslId = "Debian-12",
     matchPattern = "*Debian*12*",
@@ -200,6 +206,7 @@ val ubuntu1604 = Distribution(
 
 val distributions = listOf(
     *alpineDistributions.toTypedArray(),
+    debian13,
     debian12,
     debian11,
     debian,

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -68,8 +68,9 @@ val environments = listOf(
 
 val alpine = Distribution(
     wslId = "Alpine",
-    matchPattern = "*Alpine*",
-    defaultAbsentTool = "dos2unix"
+    matchPattern = "*Alpine*3.17*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
 )
 
 val debian11 = Distribution(
@@ -131,8 +132,7 @@ val ubuntu1604 = Distribution(
 )
 
 val distributions = listOf(
-    // disable testing on Alpine for the time being due to https://github.com/Vampire/setup-wsl/issues/82
-    //alpine,
+    alpine,
     debian11,
     debian,
     kali,
@@ -473,7 +473,7 @@ workflowWithCopyright(
         )
         runAfterSuccess(
             name = "Add user test",
-            command = "useradd -m -p 4qBD5NWD3IkbU test"
+            command = expr("matrix.distribution.create-test-user-command")
         )
         executeActionStep = usesSelfAfterSuccess(
             name = "Set wsl-bash wrapper to use user test by default",
@@ -1141,7 +1141,15 @@ workflowWithCopyright(
                     name = "Execute action for ${expr("matrix.distributions.distribution$it.user-id")}",
                     action = SetupWsl(
                         distribution = SetupWsl.Distribution.Custom(expr("matrix.distributions.distribution$it.user-id")),
-                        //additionalPackages = if (it == 2) listOf("bash") else null,
+                        additionalPackages = listOf(
+                            expr(
+                                """
+                                    (${getOnDistributionCondition(it, alpine)})
+                                    && 'bash'
+                                    || ''
+                                """.trimIndent()
+                            )
+                        ),
                         setAsDefault = if (it >= 3) false else null,
                         wslVersion = 1
                     )
@@ -1152,7 +1160,7 @@ workflowWithCopyright(
                 verifyInstalledDistribution(
                     name = "Test - wsl-bash_${expr("matrix.distributions.distribution$i.user-id")} should use the correct distribution",
                     conditionTransformer = if (distributions[i] == ubuntu2004.asMap) {
-                        { executeActionStep.getSuccessNotOnDistributionCondition(ubuntu2004, i) }
+                        { executeActionStep.getSuccessNotOnDistributionCondition(i, ubuntu2004) }
                     } else {
                         { it }
                     },
@@ -1164,7 +1172,7 @@ workflowWithCopyright(
                 if (distributions[i] == ubuntu2004.asMap) {
                     verifyInstalledDistribution(
                         name = "Test - wsl-bash_${expr("matrix.distributions.distribution$i.user-id")} should use the correct distribution",
-                        conditionTransformer = { executeActionStep.getSuccessNotOnDistributionCondition(ubuntu2204, i) },
+                        conditionTransformer = { executeActionStep.getSuccessNotOnDistributionCondition(i, ubuntu2204) },
                         shell = Shell.Custom("wsl-bash_${distributions[i]["user-id"]} {0}"),
                         expectedPatternExpression = "matrix.distributions.distribution$i.match-pattern"
                     )
@@ -1365,18 +1373,55 @@ val Step<*>.successCondition
         && (${outcome.eq(Success)})
     """.trimIndent()
 
-fun Step<*>.getSuccessOnDistributionCondition(distribution: Distribution, i: Int? = null) =
-    getSuccessOnOrNotOnDistributionCondition(distribution, true, i)
+fun Step<*>.getSuccessOnDistributionCondition(vararg distributions: Distribution) =
+    getSuccessOnOrNotOnDistributionCondition(distributions, true, null)
 
-fun Step<*>.getSuccessNotOnDistributionCondition(distribution: Distribution, i: Int? = null) =
-    getSuccessOnOrNotOnDistributionCondition(distribution, false, i)
+fun Step<*>.getSuccessOnDistributionCondition(i: Int, vararg distributions: Distribution) =
+    getSuccessOnOrNotOnDistributionCondition(distributions, true, i)
 
-fun Step<*>.getSuccessOnOrNotOnDistributionCondition(distribution: Distribution, on: Boolean = true, i: Int? = null) = """
-    |(
-        ${successCondition.prependIndent("|    ")}
-    |)
-    |&& (matrix.${i?.let { "distributions.distribution$it" } ?: "distribution"}.user-id ${if (on) "==" else "!="} '${distribution.userId}')
-""".trimMargin()
+fun Step<*>.getSuccessNotOnDistributionCondition(vararg distributions: Distribution) =
+    getSuccessOnOrNotOnDistributionCondition(distributions, false, null)
+
+fun Step<*>.getSuccessNotOnDistributionCondition(i: Int, vararg distributions: Distribution) =
+    getSuccessOnOrNotOnDistributionCondition(distributions, false, i)
+
+fun Step<*>.getSuccessOnOrNotOnDistributionCondition(distributions: Array<out Distribution>, on: Boolean = true, i: Int? = null): String {
+    return """
+        |(
+            ${successCondition.prependIndent("|    ")}
+        |)
+        |&& (${getOnOrNotOnDistributionCondition(distributions, on, i)})
+    """.trimMargin()
+}
+
+fun getOnDistributionCondition(vararg distributions: Distribution) =
+    getOnOrNotOnDistributionCondition(distributions, true, null)
+
+fun getOnDistributionCondition(i: Int, vararg distributions: Distribution) =
+    getOnOrNotOnDistributionCondition(distributions, true, i)
+
+fun getNotOnDistributionCondition(vararg distributions: Distribution) =
+    getOnOrNotOnDistributionCondition(distributions, false, null)
+
+fun getNotOnDistributionCondition(i: Int, vararg distributions: Distribution) =
+    getOnOrNotOnDistributionCondition(distributions, false, i)
+
+fun getOnOrNotOnDistributionCondition(
+    distributions: Array<out Distribution>,
+    on: Boolean = true,
+    i: Int? = null
+): String {
+    val contains = "${if (on) "" else "!"}contains"
+    val distributionsJson = distributions.joinToString(
+        separator = """", """",
+        prefix = """fromJSON('["""",
+        postfix = """"]')"""
+    ) {
+        it.userId
+    }
+    val distribution = "matrix.${i?.let { "distributions.distribution$it" } ?: "distribution"}.user-id"
+    return "$contains($distributionsJson, $distribution)"
+}
 
 // part of work-around for https://bugs.kali.org/view.php?id=8921
 // and https://bugs.kali.org/view.php?id=6672
@@ -1398,12 +1443,14 @@ data class Distribution(
     val wslId: String,
     val userId: String = wslId,
     val matchPattern: String,
-    val defaultAbsentTool: String
+    val defaultAbsentTool: String,
+    val createTestUserCommand: String = "useradd -m -p 4qBD5NWD3IkbU test"
 ) {
     val asMap = mapOf(
         "wsl-id" to wslId,
         "user-id" to userId,
         "match-pattern" to matchPattern,
-        "default-absent-tool" to defaultAbsentTool
+        "default-absent-tool" to defaultAbsentTool,
+        "create-test-user-command" to createTestUserCommand
     )
 }

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -66,17 +66,22 @@ val environments = listOf(
     "windows-latest"
 )
 
-val debian = Distribution(
-    wslId = "Debian",
-    userId = "Debian",
-    matchPattern = "*Debian*",
+val alpine = Distribution(
+    wslId = "Alpine",
+    matchPattern = "*Alpine*",
     defaultAbsentTool = "dos2unix"
 )
 
-val alpine = Distribution(
-    wslId = "Alpine",
-    userId = "Alpine",
-    matchPattern = "*Alpine*",
+val debian11 = Distribution(
+    wslId = "Debian",
+    userId = "Debian-11",
+    matchPattern = "*Debian*11*",
+    defaultAbsentTool = "dos2unix"
+)
+
+val debian = Distribution(
+    wslId = "Debian",
+    matchPattern = "*Debian*11*",
     defaultAbsentTool = "dos2unix"
 )
 
@@ -89,14 +94,12 @@ val kali = Distribution(
 
 val openSuseLeap15_2 = Distribution(
     wslId = "openSUSE-Leap-15.2",
-    userId = "openSUSE-Leap-15.2",
     matchPattern = "*openSUSE*Leap*15.2*",
     defaultAbsentTool = "which"
 )
 
 val ubuntu2404 = Distribution(
     wslId = "Ubuntu-24.04",
-    userId = "Ubuntu-24.04",
     matchPattern = "*Ubuntu*24.04*",
     defaultAbsentTool = "dos2unix"
 )
@@ -117,22 +120,21 @@ val ubuntu2004 = Distribution(
 
 val ubuntu1804 = Distribution(
     wslId = "Ubuntu-18.04",
-    userId = "Ubuntu-18.04",
     matchPattern = "*Ubuntu*18.04*",
     defaultAbsentTool = "dos2unix"
 )
 
 val ubuntu1604 = Distribution(
     wslId = "Ubuntu-16.04",
-    userId = "Ubuntu-16.04",
     matchPattern = "*Ubuntu*16.04*",
     defaultAbsentTool = "dos2unix"
 )
 
 val distributions = listOf(
-    debian,
     // disable testing on Alpine for the time being due to https://github.com/Vampire/setup-wsl/issues/82
     //alpine,
+    debian11,
+    debian,
     kali,
     openSuseLeap15_2,
     ubuntu2404,
@@ -901,34 +903,34 @@ workflowWithCopyright(
                     "environment" to environments,
                     "distributions" to listOf(
                         mapOf(
-                            "distribution1" to debian,
+                            "distribution1" to debian11,
                             "distribution2" to ubuntu2004,
                             "distribution3" to ubuntu1804
                         ),
                         mapOf(
-                            "distribution1" to debian,
+                            "distribution1" to debian11,
                             "distribution2" to ubuntu1804,
                             "distribution3" to ubuntu2004
                         ),
                         mapOf(
                             "distribution1" to ubuntu2004,
-                            "distribution2" to debian,
+                            "distribution2" to debian11,
                             "distribution3" to ubuntu1804
                         ),
                         mapOf(
                             "distribution1" to ubuntu2004,
                             "distribution2" to ubuntu1804,
-                            "distribution3" to debian
+                            "distribution3" to debian11
                         ),
                         mapOf(
                             "distribution1" to ubuntu1804,
-                            "distribution2" to debian,
+                            "distribution2" to debian11,
                             "distribution3" to ubuntu2004
                         ),
                         mapOf(
                             "distribution1" to ubuntu1804,
                             "distribution2" to ubuntu2004,
-                            "distribution3" to debian
+                            "distribution3" to debian11
                         )
                     ).map {
                         it.mapValues { (_, distribution) -> distribution.asMap }
@@ -991,18 +993,18 @@ workflowWithCopyright(
                 "matrix" to mapOf(
                     "environment" to environments,
                     "distribution" to distributions,
-                    "distribution2" to listOf(debian).map { it.asMap },
+                    "distribution2" to listOf(debian11).map { it.asMap },
                     "exclude" to environments.map {
                         mapOf(
                             "environment" to it,
-                            "distribution" to debian.asMap,
-                            "distribution2" to debian.asMap
+                            "distribution" to debian11.asMap,
+                            "distribution2" to debian11.asMap
                         )
                     },
                     "include" to environments.map {
                         mapOf(
                             "environment" to it,
-                            "distribution" to debian.asMap,
+                            "distribution" to debian11.asMap,
                             "distribution2" to ubuntu2004.asMap
                         )
                     }
@@ -1394,7 +1396,7 @@ fun getWslVersionExpression(vararg wsl2Distributions: Distribution) = """
 
 data class Distribution(
     val wslId: String,
-    val userId: String,
+    val userId: String = wslId,
     val matchPattern: String,
     val defaultAbsentTool: String
 ) {

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -698,10 +698,10 @@ workflowWithCopyright(
             )
         )
         runAfterSuccess(
-            name = "Test - /etc/wsl.conf should exist",
+            name = "Test - /etc/wsl.conf should have expected content",
             command = """
                 [ -f /etc/wsl.conf ]
-                cat /etc/wsl.conf
+                diff -u <(echo -e '[automount]\noptions = uid=1000') /etc/wsl.conf
             """
         )
         runAfterSuccess(
@@ -741,9 +741,14 @@ workflowWithCopyright(
             )
         )
         runAfterSuccess(
-            name = "Test - /etc/wsl.conf should not exist",
-            command = "[ ! -f /etc/wsl.conf ] || { cat /etc/wsl.conf; false; }",
-            conditionTransformer = { executeActionStep.getSuccessNotOnDistributionCondition(ubuntu2404) }
+            name = "Test - /etc/wsl.conf should not exist or not have the content we will put there",
+            command = """
+                if [ -f /etc/wsl.conf ]; then
+                    if diff -u <(echo -e '[automount]\nroot = /') /etc/wsl.conf; then
+                        false
+                    fi
+                fi
+            """
         )
         runAfterSuccess(
             name = "Test - C: should be mounted at /mnt/c",
@@ -769,10 +774,10 @@ workflowWithCopyright(
             )
         )
         runAfterSuccess(
-            name = "Test - /etc/wsl.conf should exist",
+            name = "Test - /etc/wsl.conf should have expected content",
             command = """
                 [ -f /etc/wsl.conf ]
-                cat /etc/wsl.conf
+                diff -u <(echo -e '[automount]\nroot = /') /etc/wsl.conf
             """
         )
         runAfterSuccess(

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -42,10 +42,10 @@ import io.github.typesafegithub.workflows.actions.vampire.SetupWsl
 import io.github.typesafegithub.workflows.actions.vampire.SetupWsl.Distribution.Debian
 import io.github.typesafegithub.workflows.actions.vampire.SetupWsl.Distribution.Ubuntu1604
 import io.github.typesafegithub.workflows.actions.vampire.SetupWsl.Distribution.Ubuntu1804
-import io.github.typesafegithub.workflows.domain.CommandStep
-import io.github.typesafegithub.workflows.domain.ActionStep
-import io.github.typesafegithub.workflows.domain.JobOutputs.EMPTY
 import io.github.typesafegithub.workflows.domain.AbstractResult.Status.Success
+import io.github.typesafegithub.workflows.domain.ActionStep
+import io.github.typesafegithub.workflows.domain.CommandStep
+import io.github.typesafegithub.workflows.domain.JobOutputs.EMPTY
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.RunnerType.WindowsLatest
 import io.github.typesafegithub.workflows.domain.Shell
@@ -66,11 +66,24 @@ val environments = listOf(
     "windows-latest"
 )
 
+val alpine317 = Distribution(
+    wslId = "Alpine",
+    userId = "Alpine-3.17",
+    matchPattern = "*Alpine*3.17*",
+    defaultAbsentTool = "dos2unix",
+    createTestUserCommand = "adduser -D test"
+)
+
 val alpine = Distribution(
     wslId = "Alpine",
     matchPattern = "*Alpine*3.17*",
     defaultAbsentTool = "dos2unix",
     createTestUserCommand = "adduser -D test"
+)
+
+val alpineDistributions = listOf(
+    alpine317,
+    alpine
 )
 
 val debian11 = Distribution(
@@ -132,7 +145,7 @@ val ubuntu1604 = Distribution(
 )
 
 val distributions = listOf(
-    alpine,
+    *alpineDistributions.toTypedArray(),
     debian11,
     debian,
     kali,
@@ -381,7 +394,11 @@ workflowWithCopyright(
         )
         verifyFailure(
             name = "Test - wsl-bash should fail if bash is not present by default",
-            conditionTransformer = { executeActionStep.getSuccessOnDistributionCondition(alpine) },
+            conditionTransformer = {
+                executeActionStep.getSuccessOnDistributionCondition(
+                    *alpineDistributions.toTypedArray()
+                )
+            },
             verificationShell = null,
             verificationTransformer = { _, command ->
                 """wsl sh -euc "${command.replace("==", "=")}""""
@@ -394,7 +411,9 @@ workflowWithCopyright(
                 additionalPackages = listOf("bash"),
                 wslVersion = null
             ),
-            condition = executeActionStep.getSuccessOnDistributionCondition(alpine)
+            condition = executeActionStep.getSuccessOnDistributionCondition(
+                *alpineDistributions.toTypedArray()
+            )
         )
         commonTests()
         verifyFailure(
@@ -626,7 +645,9 @@ workflowWithCopyright(
                 additionalPackages = listOf("bash"),
                 wslVersion = null
             ),
-            condition = executeActionStep.getSuccessOnDistributionCondition(alpine)
+            condition = executeActionStep.getSuccessOnDistributionCondition(
+                *alpineDistributions.toTypedArray()
+            )
         )
         runAfterSuccess(
             name = "Test - /etc/wsl.conf should exist",
@@ -667,7 +688,9 @@ workflowWithCopyright(
                 additionalPackages = listOf("bash"),
                 wslVersion = null
             ),
-            condition = executeActionStep.getSuccessOnDistributionCondition(alpine)
+            condition = executeActionStep.getSuccessOnDistributionCondition(
+                *alpineDistributions.toTypedArray()
+            )
         )
         runAfterSuccess(
             name = "Test - /etc/wsl.conf should not exist",
@@ -786,10 +809,10 @@ workflowWithCopyright(
                 additionalPackages = listOf(
                     expr(
                         """
-                        (matrix.distribution.user-id == '${alpine.userId}')
-                        && 'bash'
-                        || ''
-                    """.trimIndent()
+                            (${getOnDistributionCondition(*alpineDistributions.toTypedArray())})
+                            && 'bash'
+                            || ''
+                        """.trimIndent()
                     )
                 ),
                 wslVersion = null,
@@ -867,10 +890,10 @@ workflowWithCopyright(
                 additionalPackages = listOf(
                     expr(
                         """
-                        (matrix.distribution.user-id == '${alpine.userId}')
-                        && 'bash'
-                        || ''
-                    """.trimIndent()
+                            (${getOnDistributionCondition(*alpineDistributions.toTypedArray())})
+                            && 'bash'
+                            || ''
+                        """.trimIndent()
                     )
                 ),
                 wslVersion = null
@@ -1019,10 +1042,10 @@ workflowWithCopyright(
                 additionalPackages = listOf(
                     expr(
                         """
-                            |(matrix.distribution.user-id != '${kali.userId}')
-                            |&& 'bash'
-                            ||| ''
-                        """.trimMargin()
+                            (matrix.distribution.user-id != '${kali.userId}')
+                            && 'bash'
+                            || ''
+                        """.trimIndent()
                     )
                 ),
                 // part of work-around for https://bugs.kali.org/view.php?id=8921
@@ -1144,7 +1167,7 @@ workflowWithCopyright(
                         additionalPackages = listOf(
                             expr(
                                 """
-                                    (${getOnDistributionCondition(it, alpine)})
+                                    (${getOnDistributionCondition(it, *alpineDistributions.toTypedArray())})
                                     && 'bash'
                                     || ''
                                 """.trimIndent()
@@ -1193,7 +1216,7 @@ fun JobBuilder<*>.commonTests() {
             // do not just rely on false here, but explicitly use exit
             // in case failing commands do not make the script fail
             // and use "shell = Cmd" to capture that the wrapper script is hiding errors
-            "IF '${expr("${provocationStep.outcome}") }' NEQ 'failure' EXIT /B 1"
+            "IF '${expr("${provocationStep.outcome}")}' NEQ 'failure' EXIT /B 1"
         }
     )
     verifyFailure(
@@ -1263,7 +1286,11 @@ fun JobBuilder<*>.usesSelf(
 )
 
 fun JobBuilder<*>.deleteWslBashOnAlpine() = deleteWslBash(
-    conditionTransformer = { executeActionStep.getSuccessOnDistributionCondition(alpine)}
+    conditionTransformer = {
+        executeActionStep.getSuccessOnDistributionCondition(
+            *alpineDistributions.toTypedArray()
+        )
+    }
 )
 
 fun JobBuilder<*>.deleteWslBash(

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -134,6 +134,12 @@ val alpineDistributions = listOf(
     alpine
 )
 
+val debian12 = Distribution(
+    wslId = "Debian-12",
+    matchPattern = "*Debian*12*",
+    defaultAbsentTool = "dos2unix"
+)
+
 val debian11 = Distribution(
     wslId = "Debian",
     userId = "Debian-11",
@@ -194,6 +200,7 @@ val ubuntu1604 = Distribution(
 
 val distributions = listOf(
     *alpineDistributions.toTypedArray(),
+    debian12,
     debian11,
     debian,
     kali,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -389,6 +389,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -481,7 +511,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Test - wsl-bash should fail if bash is not present by default (verification)'
       run: 'wsl sh -euc "[ ''${{ steps.step-3.outcome }}'' = ''failure'' ]"'
@@ -490,7 +520,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Delete wsl-bash'
       shell: 'cmd'
@@ -500,7 +530,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-6'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -512,7 +542,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-7'
       name: 'Test - wsl-bash should be available as custom shell'
       shell: 'wsl-bash {0}'
@@ -932,6 +962,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -1020,7 +1080,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -1032,7 +1092,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should exist'
       shell: 'wsl-bash {0}'
@@ -1065,6 +1125,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -1150,7 +1240,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -1162,7 +1252,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should not exist'
       shell: 'wsl-bash {0}'
@@ -1234,6 +1324,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -1351,6 +1471,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -1430,7 +1580,7 @@ jobs:
       with:
         distribution: '${{ matrix.distribution.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
           && 'bash'
           || '' }}
         wsl-version: '${{ matrix.wsl-version }}'
@@ -1512,6 +1662,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -1588,7 +1768,7 @@ jobs:
       with:
         distribution: '${{ matrix.distribution.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
           && 'bash'
           || '' }}
     - id: 'step-3'
@@ -1793,6 +1973,36 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine-3.23'
+          user-id: 'Alpine-3.23'
+          match-pattern: '*Alpine*3.23*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.22'
+          user-id: 'Alpine-3.22'
+          match-pattern: '*Alpine*3.22*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.21'
+          user-id: 'Alpine-3.21'
+          match-pattern: '*Alpine*3.21*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.20'
+          user-id: 'Alpine-3.20'
+          match-pattern: '*Alpine*3.20*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.19'
+          user-id: 'Alpine-3.19'
+          match-pattern: '*Alpine*3.19*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine-3.18'
+          user-id: 'Alpine-3.18'
+          match-pattern: '*Alpine*3.18*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine-3.17'
           match-pattern: '*Alpine*3.17*'
@@ -2070,60 +2280,96 @@ jobs:
         distributions:
         - incompatibleUbuntu: 'Ubuntu-22.04'
           distribution1:
+            wsl-id: 'Alpine-3.23'
+            user-id: 'Alpine-3.23'
+            match-pattern: '*Alpine*3.23*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution2:
+            wsl-id: 'Alpine-3.22'
+            user-id: 'Alpine-3.22'
+            match-pattern: '*Alpine*3.22*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution3:
+            wsl-id: 'Alpine-3.21'
+            user-id: 'Alpine-3.21'
+            match-pattern: '*Alpine*3.21*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution4:
+            wsl-id: 'Alpine-3.20'
+            user-id: 'Alpine-3.20'
+            match-pattern: '*Alpine*3.20*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution5:
+            wsl-id: 'Alpine-3.19'
+            user-id: 'Alpine-3.19'
+            match-pattern: '*Alpine*3.19*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution6:
+            wsl-id: 'Alpine-3.18'
+            user-id: 'Alpine-3.18'
+            match-pattern: '*Alpine*3.18*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution7:
             wsl-id: 'Alpine'
             user-id: 'Alpine-3.17'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
-          distribution2:
+          distribution8:
             wsl-id: 'Alpine'
             user-id: 'Alpine'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
-          distribution3:
+          distribution9:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution4:
+          distribution10:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution5:
+          distribution11:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution6:
+          distribution12:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution7:
+          distribution13:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution8:
+          distribution14:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution9:
+          distribution15:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution16:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2131,60 +2377,96 @@ jobs:
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - incompatibleUbuntu: 'Ubuntu-20.04'
           distribution1:
+            wsl-id: 'Alpine-3.23'
+            user-id: 'Alpine-3.23'
+            match-pattern: '*Alpine*3.23*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution2:
+            wsl-id: 'Alpine-3.22'
+            user-id: 'Alpine-3.22'
+            match-pattern: '*Alpine*3.22*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution3:
+            wsl-id: 'Alpine-3.21'
+            user-id: 'Alpine-3.21'
+            match-pattern: '*Alpine*3.21*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution4:
+            wsl-id: 'Alpine-3.20'
+            user-id: 'Alpine-3.20'
+            match-pattern: '*Alpine*3.20*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution5:
+            wsl-id: 'Alpine-3.19'
+            user-id: 'Alpine-3.19'
+            match-pattern: '*Alpine*3.19*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution6:
+            wsl-id: 'Alpine-3.18'
+            user-id: 'Alpine-3.18'
+            match-pattern: '*Alpine*3.18*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution7:
             wsl-id: 'Alpine'
             user-id: 'Alpine-3.17'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
-          distribution2:
+          distribution8:
             wsl-id: 'Alpine'
             user-id: 'Alpine'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
-          distribution3:
+          distribution9:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution4:
+          distribution10:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution5:
+          distribution11:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution6:
+          distribution12:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution7:
+          distribution13:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution8:
+          distribution14:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution9:
+          distribution15:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution16:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2211,7 +2493,7 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution1.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution1.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution1.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2221,7 +2503,7 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution2.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution2.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution2.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2232,7 +2514,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution3.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution3.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution3.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2243,7 +2525,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution4.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution4.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution4.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2254,7 +2536,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution5.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution5.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution5.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2265,7 +2547,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution6.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution6.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution6.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2276,7 +2558,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution7.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution7.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution7.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2287,7 +2569,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution8.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution8.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution8.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2298,7 +2580,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution9.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution9.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution9.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2309,112 +2591,232 @@ jobs:
         distribution: '${{ matrix.distributions.distribution10.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution10.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution10.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
     - id: 'step-12'
+      name: 'Execute action for ${{ matrix.distributions.distribution11.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution11.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution11.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-13'
+      name: 'Execute action for ${{ matrix.distributions.distribution12.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution12.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution12.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-14'
+      name: 'Execute action for ${{ matrix.distributions.distribution13.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution13.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution13.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-15'
+      name: 'Execute action for ${{ matrix.distributions.distribution14.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution14.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution14.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-16'
+      name: 'Execute action for ${{ matrix.distributions.distribution15.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution15.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution15.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-17'
+      name: 'Execute action for ${{ matrix.distributions.distribution16.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution16.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution16.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-18'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Alpine-3.17 {0}'
+      shell: 'wsl-bash_Alpine-3.23 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution1.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-13'
+    - id: 'step-19'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Alpine {0}'
+      shell: 'wsl-bash_Alpine-3.22 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution2.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-14'
+    - id: 'step-20'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-11 {0}'
+      shell: 'wsl-bash_Alpine-3.21 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution3.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-15'
+    - id: 'step-21'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Alpine-3.20 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution4.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-16'
+    - id: 'step-22'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Alpine-3.19 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution5.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-6.outcome == 'success')
-    - id: 'step-17'
+    - id: 'step-23'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_Alpine-3.18 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-7.outcome == 'success')
-    - id: 'step-18'
+    - id: 'step-24'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_Alpine-3.17 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-8.outcome == 'success')
-    - id: 'step-19'
+    - id: 'step-25'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
+      shell: 'wsl-bash_Alpine {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-9.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution8.user-id))
-    - id: 'step-20'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-9.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution8.user-id))
-    - id: 'step-21'
+        always()
+        && (steps.step-9.outcome == 'success')
+    - id: 'step-26'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution9.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution9.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-10.outcome == 'success')
-    - id: 'step-22'
+    - id: 'step-27'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution10.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution10.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-11.outcome == 'success')
+    - id: 'step-28'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution11.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_kali-linux {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution11.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-12.outcome == 'success')
+    - id: 'step-29'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution12.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution12.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-13.outcome == 'success')
+    - id: 'step-30'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution13.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution13.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-14.outcome == 'success')
+    - id: 'step-31'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution14.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution14.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-15.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution14.user-id))
+    - id: 'step-32'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution14.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution14.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-15.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution14.user-id))
+    - id: 'step-33'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution15.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution15.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-16.outcome == 'success')
+    - id: 'step-34'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution16.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution16.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-17.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -390,6 +390,11 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
@@ -476,7 +481,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Test - wsl-bash should fail if bash is not present by default (verification)'
       run: 'wsl sh -euc "[ ''${{ steps.step-3.outcome }}'' = ''failure'' ]"'
@@ -485,7 +490,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Delete wsl-bash'
       shell: 'cmd'
@@ -495,7 +500,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-6'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -507,7 +512,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-7'
       name: 'Test - wsl-bash should be available as custom shell'
       shell: 'wsl-bash {0}'
@@ -928,6 +933,11 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
@@ -1010,7 +1020,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -1022,7 +1032,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should exist'
       shell: 'wsl-bash {0}'
@@ -1055,6 +1065,11 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
@@ -1135,7 +1150,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -1147,7 +1162,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
+        && (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should not exist'
       shell: 'wsl-bash {0}'
@@ -1219,6 +1234,11 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
@@ -1332,6 +1352,11 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
@@ -1405,7 +1430,7 @@ jobs:
       with:
         distribution: '${{ matrix.distribution.user-id }}'
         additional-packages: |-
-          ${{ (matrix.distribution.user-id == 'Alpine')
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
           && 'bash'
           || '' }}
         wsl-version: '${{ matrix.wsl-version }}'
@@ -1488,6 +1513,11 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
@@ -1558,7 +1588,7 @@ jobs:
       with:
         distribution: '${{ matrix.distribution.user-id }}'
         additional-packages: |-
-          ${{ (matrix.distribution.user-id == 'Alpine')
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
           && 'bash'
           || '' }}
     - id: 'step-3'
@@ -1763,6 +1793,11 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine-3.17'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Alpine'
           user-id: 'Alpine'
           match-pattern: '*Alpine*3.17*'
@@ -2036,53 +2071,59 @@ jobs:
         - incompatibleUbuntu: 'Ubuntu-22.04'
           distribution1:
             wsl-id: 'Alpine'
-            user-id: 'Alpine'
+            user-id: 'Alpine-3.17'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution2:
+            wsl-id: 'Alpine'
+            user-id: 'Alpine'
+            match-pattern: '*Alpine*3.17*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution3:
+          distribution4:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution4:
+          distribution5:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution5:
+          distribution6:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution6:
+          distribution7:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution7:
+          distribution8:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution8:
+          distribution9:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution9:
+          distribution10:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2091,53 +2132,59 @@ jobs:
         - incompatibleUbuntu: 'Ubuntu-20.04'
           distribution1:
             wsl-id: 'Alpine'
-            user-id: 'Alpine'
+            user-id: 'Alpine-3.17'
             match-pattern: '*Alpine*3.17*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution2:
+            wsl-id: 'Alpine'
+            user-id: 'Alpine'
+            match-pattern: '*Alpine*3.17*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution3:
+          distribution4:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution4:
+          distribution5:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution5:
+          distribution6:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution6:
+          distribution7:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution7:
+          distribution8:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution8:
+          distribution9:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution9:
+          distribution10:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2164,7 +2211,7 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution1.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution1.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution1.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2174,7 +2221,7 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution2.user-id }}'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution2.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution2.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2185,7 +2232,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution3.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution3.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution3.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2196,7 +2243,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution4.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution4.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution4.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2207,7 +2254,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution5.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution5.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution5.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2218,7 +2265,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution6.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution6.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution6.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2229,7 +2276,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution7.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution7.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution7.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2240,7 +2287,7 @@ jobs:
         distribution: '${{ matrix.distributions.distribution8.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution8.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution8.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
@@ -2251,103 +2298,123 @@ jobs:
         distribution: '${{ matrix.distributions.distribution9.user-id }}'
         set-as-default: 'false'
         additional-packages: |-
-          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution9.user-id))
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution9.user-id))
           && 'bash'
           || '' }}
         wsl-version: '1'
     - id: 'step-11'
+      name: 'Execute action for ${{ matrix.distributions.distribution10.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution10.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.17", "Alpine"]'), matrix.distributions.distribution10.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-12'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Alpine {0}'
+      shell: 'wsl-bash_Alpine-3.17 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution1.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-12'
+    - id: 'step-13'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-11 {0}'
+      shell: 'wsl-bash_Alpine {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution2.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-13'
+    - id: 'step-14'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution3.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-14'
+    - id: 'step-15'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution4.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-15'
+    - id: 'step-16'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_kali-linux {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution5.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-6.outcome == 'success')
-    - id: 'step-16'
+    - id: 'step-17'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-7.outcome == 'success')
-    - id: 'step-17'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-8.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution7.user-id))
     - id: 'step-18'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-8.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution7.user-id))
+        always()
+        && (steps.step-8.outcome == 'success')
     - id: 'step-19'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
       if: |-
-        always()
-        && (steps.step-9.outcome == 'success')
+        (
+            always()
+            && (steps.step-9.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution8.user-id))
     - id: 'step-20'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-9.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution8.user-id))
+    - id: 'step-21'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution9.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution9.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-10.outcome == 'success')
+    - id: 'step-22'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution10.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution10.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-11.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -429,6 +429,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -1007,6 +1012,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -1175,6 +1185,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -1381,6 +1396,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -1533,6 +1553,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -1729,6 +1754,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -2045,6 +2075,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-13'
+          user-id: 'Debian-13'
+          match-pattern: '*Debian*13*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian-12'
           user-id: 'Debian-12'
           match-pattern: '*Debian*12*'
@@ -2365,54 +2400,60 @@ jobs:
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution9:
+            wsl-id: 'Debian-13'
+            user-id: 'Debian-13'
+            match-pattern: '*Debian*13*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution10:
             wsl-id: 'Debian-12'
             user-id: 'Debian-12'
             match-pattern: '*Debian*12*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution11:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution11:
+          distribution12:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution12:
+          distribution13:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution13:
+          distribution14:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution14:
+          distribution15:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution15:
+          distribution16:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution16:
+          distribution17:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution17:
+          distribution18:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2468,54 +2509,60 @@ jobs:
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution9:
+            wsl-id: 'Debian-13'
+            user-id: 'Debian-13'
+            match-pattern: '*Debian*13*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution10:
             wsl-id: 'Debian-12'
             user-id: 'Debian-12'
             match-pattern: '*Debian*12*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution11:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution11:
+          distribution12:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution12:
+          distribution13:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution13:
+          distribution14:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution14:
+          distribution15:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution15:
+          distribution16:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution16:
+          distribution17:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution17:
+          distribution18:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2722,6 +2769,17 @@ jobs:
           || '' }}
         wsl-version: '1'
     - id: 'step-19'
+      name: 'Execute action for ${{ matrix.distributions.distribution18.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution18.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution18.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-20'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.23 {0}'
       run: |-
@@ -2730,7 +2788,7 @@ jobs:
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-20'
+    - id: 'step-21'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.22 {0}'
       run: |-
@@ -2739,7 +2797,7 @@ jobs:
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-21'
+    - id: 'step-22'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.21 {0}'
       run: |-
@@ -2748,7 +2806,7 @@ jobs:
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-22'
+    - id: 'step-23'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.20 {0}'
       run: |-
@@ -2757,7 +2815,7 @@ jobs:
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-23'
+    - id: 'step-24'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.19 {0}'
       run: |-
@@ -2766,7 +2824,7 @@ jobs:
       if: |-
         always()
         && (steps.step-6.outcome == 'success')
-    - id: 'step-24'
+    - id: 'step-25'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.18 {0}'
       run: |-
@@ -2775,7 +2833,7 @@ jobs:
       if: |-
         always()
         && (steps.step-7.outcome == 'success')
-    - id: 'step-25'
+    - id: 'step-26'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.17 {0}'
       run: |-
@@ -2784,7 +2842,7 @@ jobs:
       if: |-
         always()
         && (steps.step-8.outcome == 'success')
-    - id: 'step-26'
+    - id: 'step-27'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine {0}'
       run: |-
@@ -2793,99 +2851,108 @@ jobs:
       if: |-
         always()
         && (steps.step-9.outcome == 'success')
-    - id: 'step-27'
+    - id: 'step-28'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution9.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-12 {0}'
+      shell: 'wsl-bash_Debian-13 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution9.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-10.outcome == 'success')
-    - id: 'step-28'
+    - id: 'step-29'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution10.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-11 {0}'
+      shell: 'wsl-bash_Debian-12 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution10.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-11.outcome == 'success')
-    - id: 'step-29'
+    - id: 'step-30'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution11.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution11.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-12.outcome == 'success')
-    - id: 'step-30'
+    - id: 'step-31'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution12.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution12.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-13.outcome == 'success')
-    - id: 'step-31'
+    - id: 'step-32'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution13.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_kali-linux {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution13.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-14.outcome == 'success')
-    - id: 'step-32'
+    - id: 'step-33'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution14.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution14.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-15.outcome == 'success')
-    - id: 'step-33'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution15.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution15.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-16.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution15.user-id))
     - id: 'step-34'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution15.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution15.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-16.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution15.user-id))
+        always()
+        && (steps.step-16.outcome == 'success')
     - id: 'step-35'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution16.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution16.match-pattern }} ]]
       if: |-
-        always()
-        && (steps.step-17.outcome == 'success')
+        (
+            always()
+            && (steps.step-17.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution16.user-id))
     - id: 'step-36'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution16.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution16.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-17.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution16.user-id))
+    - id: 'step-37'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution17.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution17.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-18.outcome == 'success')
+    - id: 'step-38'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution18.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution18.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-19.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -182,6 +182,7 @@ jobs:
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -388,42 +389,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -461,7 +476,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Test - wsl-bash should fail if bash is not present by default (verification)'
       run: 'wsl sh -euc "[ ''${{ steps.step-3.outcome }}'' = ''failure'' ]"'
@@ -470,7 +485,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Delete wsl-bash'
       shell: 'cmd'
@@ -480,7 +495,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-6'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -492,7 +507,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-7'
       name: 'Test - wsl-bash should be available as custom shell'
       shell: 'wsl-bash {0}'
@@ -725,7 +740,7 @@ jobs:
     - id: 'step-36'
       name: 'Add user test'
       shell: 'wsl-bash {0}'
-      run: 'useradd -m -p 4qBD5NWD3IkbU test'
+      run: '${{ matrix.distribution.create-test-user-command }}'
       if: |-
         always()
         && (steps.step-32.outcome == 'success')
@@ -912,42 +927,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -981,7 +1010,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -993,7 +1022,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should exist'
       shell: 'wsl-bash {0}'
@@ -1026,42 +1055,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -1092,7 +1135,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-4'
       name: 'Install Bash on Alpine'
       uses: './'
@@ -1104,7 +1147,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id == 'Alpine')
+        && (contains(fromJSON('["Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
       name: 'Test - /etc/wsl.conf should not exist'
       shell: 'wsl-bash {0}'
@@ -1114,7 +1157,7 @@ jobs:
             always()
             && (steps.step-2.outcome == 'success')
         )
-        && (matrix.distribution.user-id != 'Ubuntu-24.04')
+        && (!contains(fromJSON('["Ubuntu-24.04"]'), matrix.distribution.user-id))
     - id: 'step-6'
       name: 'Test - C: should be mounted at /mnt/c'
       shell: 'wsl-bash {0}'
@@ -1176,42 +1219,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -1274,42 +1331,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         wsl-version:
         - 1
         - 2
@@ -1416,42 +1487,56 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -1504,91 +1589,109 @@ jobs:
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - distribution1:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - distribution1:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - distribution1:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - distribution1:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - distribution1:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -1660,47 +1763,62 @@ jobs:
         - 'windows-2025'
         - 'windows-latest'
         distribution:
+        - wsl-id: 'Alpine'
+          user-id: 'Alpine'
+          match-pattern: '*Alpine*3.17*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'adduser -D test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
           match-pattern: '*Kali*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'openSUSE-Leap-15.2'
           user-id: 'openSUSE-Leap-15.2'
           match-pattern: '*openSUSE*Leap*15.2*'
           default-absent-tool: 'which'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-24.04'
           user-id: 'Ubuntu-24.04'
           match-pattern: '*Ubuntu*24.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-22.04'
           match-pattern: '*Ubuntu*22.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu'
           user-id: 'Ubuntu-20.04'
           match-pattern: '*Ubuntu*20.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-18.04'
           user-id: 'Ubuntu-18.04'
           match-pattern: '*Ubuntu*18.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Ubuntu-16.04'
           user-id: 'Ubuntu-16.04'
           match-pattern: '*Ubuntu*16.04*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         distribution2:
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         exclude:
         - environment: 'windows-2022'
           distribution:
@@ -1708,33 +1826,39 @@ jobs:
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - environment: 'windows-2025'
           distribution:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - environment: 'windows-latest'
           distribution:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         include:
         - environment: 'windows-2022'
           distribution:
@@ -1742,33 +1866,39 @@ jobs:
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - environment: 'windows-2025'
           distribution:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - environment: 'windows-latest'
           distribution:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
           distribution2:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -1905,86 +2035,114 @@ jobs:
         distributions:
         - incompatibleUbuntu: 'Ubuntu-22.04'
           distribution1:
+            wsl-id: 'Alpine'
+            user-id: 'Alpine'
+            match-pattern: '*Alpine*3.17*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
-          distribution2:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
-          distribution3:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution4:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
-          distribution4:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution5:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
-          distribution5:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution6:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
-          distribution6:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution7:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
-          distribution7:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution8:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
-          distribution8:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution9:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - incompatibleUbuntu: 'Ubuntu-20.04'
           distribution1:
+            wsl-id: 'Alpine'
+            user-id: 'Alpine'
+            match-pattern: '*Alpine*3.17*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'adduser -D test'
+          distribution2:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
-          distribution2:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution3:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
-          distribution3:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution4:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
-          distribution4:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution5:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
-          distribution5:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution6:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
-          distribution6:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution7:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
-          distribution7:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution8:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
-          distribution8:
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution9:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
             default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
     steps:
     - id: 'step-0'
       name: 'Install zstd on windows-11-arm'
@@ -2005,12 +2163,20 @@ jobs:
       uses: './'
       with:
         distribution: '${{ matrix.distributions.distribution1.user-id }}'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution1.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-3'
       name: 'Execute action for ${{ matrix.distributions.distribution2.user-id }}'
       uses: './'
       with:
         distribution: '${{ matrix.distributions.distribution2.user-id }}'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution2.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-4'
       name: 'Execute action for ${{ matrix.distributions.distribution3.user-id }}'
@@ -2018,6 +2184,10 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution3.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution3.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-5'
       name: 'Execute action for ${{ matrix.distributions.distribution4.user-id }}'
@@ -2025,6 +2195,10 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution4.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution4.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-6'
       name: 'Execute action for ${{ matrix.distributions.distribution5.user-id }}'
@@ -2032,6 +2206,10 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution5.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution5.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-7'
       name: 'Execute action for ${{ matrix.distributions.distribution6.user-id }}'
@@ -2039,6 +2217,10 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution6.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution6.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-8'
       name: 'Execute action for ${{ matrix.distributions.distribution7.user-id }}'
@@ -2046,6 +2228,10 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution7.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution7.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-9'
       name: 'Execute action for ${{ matrix.distributions.distribution8.user-id }}'
@@ -2053,91 +2239,115 @@ jobs:
       with:
         distribution: '${{ matrix.distributions.distribution8.user-id }}'
         set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution8.user-id))
+          && 'bash'
+          || '' }}
         wsl-version: '1'
     - id: 'step-10'
+      name: 'Execute action for ${{ matrix.distributions.distribution9.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution9.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine"]'), matrix.distributions.distribution9.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-11'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-11 {0}'
+      shell: 'wsl-bash_Alpine {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution1.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-11'
+    - id: 'step-12'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution2.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-12'
+    - id: 'step-13'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution3.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-13'
+    - id: 'step-14'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_kali-linux {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution4.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-14'
+    - id: 'step-15'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution5.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-6.outcome == 'success')
-    - id: 'step-15'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-7.outcome == 'success')
-        )
-        && (matrix.distributions.distribution6.user-id != 'Ubuntu-20.04')
     - id: 'step-16'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-7.outcome == 'success')
-        )
-        && (matrix.distributions.distribution6.user-id != 'Ubuntu-22.04')
+        always()
+        && (steps.step-7.outcome == 'success')
     - id: 'step-17'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
       if: |-
-        always()
-        && (steps.step-8.outcome == 'success')
+        (
+            always()
+            && (steps.step-8.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution7.user-id))
     - id: 'step-18'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-8.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution7.user-id))
+    - id: 'step-19'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-9.outcome == 'success')
+    - id: 'step-20'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution9.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution9.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-10.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1094,11 +1094,11 @@ jobs:
         )
         && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
-      name: 'Test - /etc/wsl.conf should exist'
+      name: 'Test - /etc/wsl.conf should have expected content'
       shell: 'wsl-bash {0}'
       run: |-
         [ -f /etc/wsl.conf ]
-        cat /etc/wsl.conf
+        diff -u <(echo -e '[automount]\noptions = uid=1000') /etc/wsl.conf
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
@@ -1254,15 +1254,17 @@ jobs:
         )
         && (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distribution.user-id))
     - id: 'step-5'
-      name: 'Test - /etc/wsl.conf should not exist'
+      name: 'Test - /etc/wsl.conf should not exist or not have the content we will put there'
       shell: 'wsl-bash {0}'
-      run: '[ ! -f /etc/wsl.conf ] || { cat /etc/wsl.conf; false; }'
+      run: |-
+        if [ -f /etc/wsl.conf ]; then
+            if diff -u <(echo -e '[automount]\nroot = /') /etc/wsl.conf; then
+                false
+            fi
+        fi
       if: |-
-        (
-            always()
-            && (steps.step-2.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-24.04"]'), matrix.distribution.user-id))
+        always()
+        && (steps.step-2.outcome == 'success')
     - id: 'step-6'
       name: 'Test - C: should be mounted at /mnt/c'
       shell: 'wsl-bash {0}'
@@ -1293,11 +1295,11 @@ jobs:
         always()
         && (steps.step-2.outcome == 'success')
     - id: 'step-9'
-      name: 'Test - /etc/wsl.conf should exist'
+      name: 'Test - /etc/wsl.conf should have expected content'
       shell: 'wsl-bash {0}'
       run: |-
         [ -f /etc/wsl.conf ]
-        cat /etc/wsl.conf
+        diff -u <(echo -e '[automount]\nroot = /') /etc/wsl.conf
       if: |-
         always()
         && (steps.step-8.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -180,7 +180,7 @@ jobs:
         distribution:
         - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
     steps:
     - id: 'step-0'
@@ -389,8 +389,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -909,8 +913,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1019,8 +1027,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1165,8 +1177,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1259,8 +1275,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1397,8 +1417,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1477,8 +1501,8 @@ jobs:
         distributions:
         - distribution1:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Ubuntu'
@@ -1492,8 +1516,8 @@ jobs:
             default-absent-tool: 'dos2unix'
         - distribution1:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Ubuntu-18.04'
@@ -1512,8 +1536,8 @@ jobs:
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution3:
             wsl-id: 'Ubuntu-18.04'
@@ -1532,8 +1556,8 @@ jobs:
             default-absent-tool: 'dos2unix'
           distribution3:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
         - distribution1:
             wsl-id: 'Ubuntu-18.04'
@@ -1542,8 +1566,8 @@ jobs:
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution3:
             wsl-id: 'Ubuntu'
@@ -1562,8 +1586,8 @@ jobs:
             default-absent-tool: 'dos2unix'
           distribution3:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
     steps:
     - id: 'step-0'
@@ -1637,8 +1661,12 @@ jobs:
         - 'windows-latest'
         distribution:
         - wsl-id: 'Debian'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
+          default-absent-tool: 'dos2unix'
+        - wsl-id: 'Debian'
           user-id: 'Debian'
-          match-pattern: '*Debian*'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         - wsl-id: 'MyDistribution'
           user-id: 'kali-linux'
@@ -1670,49 +1698,49 @@ jobs:
           default-absent-tool: 'dos2unix'
         distribution2:
         - wsl-id: 'Debian'
-          user-id: 'Debian'
-          match-pattern: '*Debian*'
+          user-id: 'Debian-11'
+          match-pattern: '*Debian*11*'
           default-absent-tool: 'dos2unix'
         exclude:
         - environment: 'windows-2022'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
         - environment: 'windows-2025'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
         - environment: 'windows-latest'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
         include:
         - environment: 'windows-2022'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Ubuntu'
@@ -1722,8 +1750,8 @@ jobs:
         - environment: 'windows-2025'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Ubuntu'
@@ -1733,8 +1761,8 @@ jobs:
         - environment: 'windows-latest'
           distribution:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
             wsl-id: 'Ubuntu'
@@ -1878,35 +1906,40 @@ jobs:
         - incompatibleUbuntu: 'Ubuntu-22.04'
           distribution1:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
+            wsl-id: 'Debian'
+            user-id: 'Debian'
+            match-pattern: '*Debian*11*'
+            default-absent-tool: 'dos2unix'
+          distribution3:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
-          distribution3:
+          distribution4:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
-          distribution4:
+          distribution5:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
-          distribution5:
+          distribution6:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
-          distribution6:
+          distribution7:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
-          distribution7:
+          distribution8:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -1914,35 +1947,40 @@ jobs:
         - incompatibleUbuntu: 'Ubuntu-20.04'
           distribution1:
             wsl-id: 'Debian'
-            user-id: 'Debian'
-            match-pattern: '*Debian*'
+            user-id: 'Debian-11'
+            match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
           distribution2:
+            wsl-id: 'Debian'
+            user-id: 'Debian'
+            match-pattern: '*Debian*11*'
+            default-absent-tool: 'dos2unix'
+          distribution3:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
-          distribution3:
+          distribution4:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
-          distribution4:
+          distribution5:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
-          distribution5:
+          distribution6:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
-          distribution6:
+          distribution7:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
-          distribution7:
+          distribution8:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2010,80 +2048,96 @@ jobs:
         set-as-default: 'false'
         wsl-version: '1'
     - id: 'step-9'
+      name: 'Execute action for ${{ matrix.distributions.distribution8.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution8.user-id }}'
+        set-as-default: 'false'
+        wsl-version: '1'
+    - id: 'step-10'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution1.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-10'
+    - id: 'step-11'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution2.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-11'
+    - id: 'step-12'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_kali-linux {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution3.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-12'
+    - id: 'step-13'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution4.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-13'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution5.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-6.outcome == 'success')
-        )
-        && (matrix.distributions.distribution5.user-id != 'Ubuntu-20.04')
     - id: 'step-14'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution5.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-6.outcome == 'success')
-        )
-        && (matrix.distributions.distribution5.user-id != 'Ubuntu-22.04')
+        always()
+        && (steps.step-6.outcome == 'success')
     - id: 'step-15'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
       if: |-
-        always()
-        && (steps.step-7.outcome == 'success')
+        (
+            always()
+            && (steps.step-7.outcome == 'success')
+        )
+        && (matrix.distributions.distribution6.user-id != 'Ubuntu-20.04')
     - id: 'step-16'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution6.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-7.outcome == 'success')
+        )
+        && (matrix.distributions.distribution6.user-id != 'Ubuntu-22.04')
+    - id: 'step-17'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution7.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-8.outcome == 'success')
+    - id: 'step-18'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution8.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-9.outcome == 'success')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -429,6 +429,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -1002,6 +1007,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -1165,6 +1175,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -1366,6 +1381,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -1513,6 +1533,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -1704,6 +1729,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -2015,6 +2045,11 @@ jobs:
           match-pattern: '*Alpine*3.17*'
           default-absent-tool: 'dos2unix'
           create-test-user-command: 'adduser -D test'
+        - wsl-id: 'Debian-12'
+          user-id: 'Debian-12'
+          match-pattern: '*Debian*12*'
+          default-absent-tool: 'dos2unix'
+          create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
         - wsl-id: 'Debian'
           user-id: 'Debian-11'
           match-pattern: '*Debian*11*'
@@ -2330,48 +2365,54 @@ jobs:
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution9:
+            wsl-id: 'Debian-12'
+            user-id: 'Debian-12'
+            match-pattern: '*Debian*12*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution10:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution11:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution11:
+          distribution12:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution12:
+          distribution13:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution13:
+          distribution14:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution14:
+          distribution15:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-20.04'
             match-pattern: '*Ubuntu*20.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution15:
+          distribution16:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution16:
+          distribution17:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2427,48 +2468,54 @@ jobs:
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'adduser -D test'
           distribution9:
+            wsl-id: 'Debian-12'
+            user-id: 'Debian-12'
+            match-pattern: '*Debian*12*'
+            default-absent-tool: 'dos2unix'
+            create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
+          distribution10:
             wsl-id: 'Debian'
             user-id: 'Debian-11'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution10:
+          distribution11:
             wsl-id: 'Debian'
             user-id: 'Debian'
             match-pattern: '*Debian*11*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution11:
+          distribution12:
             wsl-id: 'MyDistribution'
             user-id: 'kali-linux'
             match-pattern: '*Kali*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution12:
+          distribution13:
             wsl-id: 'openSUSE-Leap-15.2'
             user-id: 'openSUSE-Leap-15.2'
             match-pattern: '*openSUSE*Leap*15.2*'
             default-absent-tool: 'which'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution13:
+          distribution14:
             wsl-id: 'Ubuntu-24.04'
             user-id: 'Ubuntu-24.04'
             match-pattern: '*Ubuntu*24.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution14:
+          distribution15:
             wsl-id: 'Ubuntu'
             user-id: 'Ubuntu-22.04'
             match-pattern: '*Ubuntu*22.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution15:
+          distribution16:
             wsl-id: 'Ubuntu-18.04'
             user-id: 'Ubuntu-18.04'
             match-pattern: '*Ubuntu*18.04*'
             default-absent-tool: 'dos2unix'
             create-test-user-command: 'useradd -m -p 4qBD5NWD3IkbU test'
-          distribution16:
+          distribution17:
             wsl-id: 'Ubuntu-16.04'
             user-id: 'Ubuntu-16.04'
             match-pattern: '*Ubuntu*16.04*'
@@ -2664,6 +2711,17 @@ jobs:
           || '' }}
         wsl-version: '1'
     - id: 'step-18'
+      name: 'Execute action for ${{ matrix.distributions.distribution17.user-id }}'
+      uses: './'
+      with:
+        distribution: '${{ matrix.distributions.distribution17.user-id }}'
+        set-as-default: 'false'
+        additional-packages: |-
+          ${{ (contains(fromJSON('["Alpine-3.23", "Alpine-3.22", "Alpine-3.21", "Alpine-3.20", "Alpine-3.19", "Alpine-3.18", "Alpine-3.17", "Alpine"]'), matrix.distributions.distribution17.user-id))
+          && 'bash'
+          || '' }}
+        wsl-version: '1'
+    - id: 'step-19'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution1.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.23 {0}'
       run: |-
@@ -2672,7 +2730,7 @@ jobs:
       if: |-
         always()
         && (steps.step-2.outcome == 'success')
-    - id: 'step-19'
+    - id: 'step-20'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution2.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.22 {0}'
       run: |-
@@ -2681,7 +2739,7 @@ jobs:
       if: |-
         always()
         && (steps.step-3.outcome == 'success')
-    - id: 'step-20'
+    - id: 'step-21'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution3.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.21 {0}'
       run: |-
@@ -2690,7 +2748,7 @@ jobs:
       if: |-
         always()
         && (steps.step-4.outcome == 'success')
-    - id: 'step-21'
+    - id: 'step-22'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution4.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.20 {0}'
       run: |-
@@ -2699,7 +2757,7 @@ jobs:
       if: |-
         always()
         && (steps.step-5.outcome == 'success')
-    - id: 'step-22'
+    - id: 'step-23'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution5.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.19 {0}'
       run: |-
@@ -2708,7 +2766,7 @@ jobs:
       if: |-
         always()
         && (steps.step-6.outcome == 'success')
-    - id: 'step-23'
+    - id: 'step-24'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution6.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.18 {0}'
       run: |-
@@ -2717,7 +2775,7 @@ jobs:
       if: |-
         always()
         && (steps.step-7.outcome == 'success')
-    - id: 'step-24'
+    - id: 'step-25'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution7.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine-3.17 {0}'
       run: |-
@@ -2726,7 +2784,7 @@ jobs:
       if: |-
         always()
         && (steps.step-8.outcome == 'success')
-    - id: 'step-25'
+    - id: 'step-26'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution8.user-id }} should use the correct distribution'
       shell: 'wsl-bash_Alpine {0}'
       run: |-
@@ -2735,90 +2793,99 @@ jobs:
       if: |-
         always()
         && (steps.step-9.outcome == 'success')
-    - id: 'step-26'
+    - id: 'step-27'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution9.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian-11 {0}'
+      shell: 'wsl-bash_Debian-12 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution9.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-10.outcome == 'success')
-    - id: 'step-27'
+    - id: 'step-28'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution10.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Debian {0}'
+      shell: 'wsl-bash_Debian-11 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution10.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-11.outcome == 'success')
-    - id: 'step-28'
+    - id: 'step-29'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution11.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_kali-linux {0}'
+      shell: 'wsl-bash_Debian {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution11.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-12.outcome == 'success')
-    - id: 'step-29'
+    - id: 'step-30'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution12.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
+      shell: 'wsl-bash_kali-linux {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution12.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-13.outcome == 'success')
-    - id: 'step-30'
+    - id: 'step-31'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution13.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-24.04 {0}'
+      shell: 'wsl-bash_openSUSE-Leap-15.2 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution13.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-14.outcome == 'success')
-    - id: 'step-31'
-      name: 'Test - wsl-bash_${{ matrix.distributions.distribution14.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-22.04 {0}'
-      run: |-
-        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
-        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution14.match-pattern }} ]]
-      if: |-
-        (
-            always()
-            && (steps.step-15.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution14.user-id))
     - id: 'step-32'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution14.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      shell: 'wsl-bash_Ubuntu-24.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution14.match-pattern }} ]]
       if: |-
-        (
-            always()
-            && (steps.step-15.outcome == 'success')
-        )
-        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution14.user-id))
+        always()
+        && (steps.step-15.outcome == 'success')
     - id: 'step-33'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution15.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-18.04 {0}'
+      shell: 'wsl-bash_Ubuntu-22.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution15.match-pattern }} ]]
       if: |-
-        always()
-        && (steps.step-16.outcome == 'success')
+        (
+            always()
+            && (steps.step-16.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-20.04"]'), matrix.distributions.distribution15.user-id))
     - id: 'step-34'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution15.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-20.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution15.match-pattern }} ]]
+      if: |-
+        (
+            always()
+            && (steps.step-16.outcome == 'success')
+        )
+        && (!contains(fromJSON('["Ubuntu-22.04"]'), matrix.distributions.distribution15.user-id))
+    - id: 'step-35'
       name: 'Test - wsl-bash_${{ matrix.distributions.distribution16.user-id }} should use the correct distribution'
-      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      shell: 'wsl-bash_Ubuntu-18.04 {0}'
       run: |-
         cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
         [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution16.match-pattern }} ]]
       if: |-
         always()
         && (steps.step-17.outcome == 'success')
+    - id: 'step-36'
+      name: 'Test - wsl-bash_${{ matrix.distributions.distribution17.user-id }} should use the correct distribution'
+      shell: 'wsl-bash_Ubuntu-16.04 {0}'
+      run: |-
+        cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true)
+        [[ "$(cat <(lsb_release -a || true) <(uname -a || true) <([ -d /etc ] && find /etc -maxdepth 1 -type f \( -name '*release' -or -name 'issue*' \) -exec cat {} + || true) <([ -d /etc/products.d ] && find /etc/products.d -maxdepth 1 -type f -name '*.prod' -exec cat {} + || true) <([ -f /proc/version ] && cat /proc/version || true))" == ${{ matrix.distributions.distribution17.match-pattern }} ]]
+      if: |-
+        always()
+        && (steps.step-18.outcome == 'success')

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Piotr Krzemiński
+# Copyright 2022-2026 Piotr Krzemiński & Björn Kautler
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ inputs:
         type: enum
         allowed-values:
             - Alpine
+            - Debian-11
             - Debian
             - kali-linux
             - openSUSE-Leap-15.2

--- a/action-types.yml
+++ b/action-types.yml
@@ -17,6 +17,7 @@ inputs:
     distribution:
         type: enum
         allowed-values:
+            - Alpine-3.17
             - Alpine
             - Debian-11
             - Debian

--- a/action-types.yml
+++ b/action-types.yml
@@ -25,6 +25,7 @@ inputs:
             - Alpine-3.18
             - Alpine-3.17
             - Alpine
+            - Debian-13
             - Debian-12
             - Debian-11
             - Debian

--- a/action-types.yml
+++ b/action-types.yml
@@ -25,6 +25,7 @@ inputs:
             - Alpine-3.18
             - Alpine-3.17
             - Alpine
+            - Debian-12
             - Debian-11
             - Debian
             - kali-linux

--- a/action-types.yml
+++ b/action-types.yml
@@ -17,6 +17,12 @@ inputs:
     distribution:
         type: enum
         allowed-values:
+            - Alpine-3.23
+            - Alpine-3.22
+            - Alpine-3.21
+            - Alpine-3.20
+            - Alpine-3.19
+            - Alpine-3.18
             - Alpine-3.17
             - Alpine
             - Debian-11

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Björn Kautler
+# Copyright 2020-2026 Björn Kautler
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,17 @@ inputs:
             'Ubuntu-22.04' and 'Ubuntu-20.04' can not be used together at the same time.
             They use the same WSL distribution ID, so the second that is used will not be installed
             as the first one will be found as already installed by WSL distribution ID.
-            Valid values: 'Alpine', 'Debian', 'kali-linux', 'openSUSE-Leap-15.2', 'Ubuntu-24.04', 'Ubuntu-22.04', 'Ubuntu-20.04', 'Ubuntu-18.04', 'Ubuntu-16.04'
+            Valid values:
+                - 'Alpine'
+                - 'Debian-11'
+                - 'Debian' (deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
+                - 'kali-linux'
+                - 'openSUSE-Leap-15.2'
+                - 'Ubuntu-24.04'
+                - 'Ubuntu-22.04'
+                - 'Ubuntu-20.04'
+                - 'Ubuntu-18.04'
+                - 'Ubuntu-16.04'
         required: false
         default: Debian
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,8 @@ inputs:
             They use the same WSL distribution ID, so the second that is used will not be installed
             as the first one will be found as already installed by WSL distribution ID.
             Valid values:
-                - 'Alpine'
+                - 'Alpine-3.17'
+                - 'Alpine' (deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
                 - 'Debian-11'
                 - 'Debian' (deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
                 - 'kali-linux'

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ inputs:
                 - 'Alpine-3.18'
                 - 'Alpine-3.17'
                 - 'Alpine' (deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
+                - 'Debian-12'
                 - 'Debian-11'
                 - 'Debian' (deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
                 - 'kali-linux'
@@ -65,6 +66,11 @@ inputs:
             This can be used to adjust various settings as documented at
             https://docs.microsoft.com/en-us/windows/wsl/wsl-config#configuration-settings-for-wslconf.
             This can also be used if the distribution is installed already.
+
+            WARNING: Setting this option will overwrite any existing content of the file.
+            Some distributions like Debian-12+ and Ubuntu-24.04+ ship with a default wsl.conf file.
+            Make sure to check whether a file exists by default and whether you want to include
+            its contents in your configured value.
         required: false
 
     set-as-default:

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
             They use the same WSL distribution ID, so the second that is used will not be installed
             as the first one will be found as already installed by WSL distribution ID.
             Valid values:
+                - 'Alpine-3.23'
+                - 'Alpine-3.22'
+                - 'Alpine-3.21'
+                - 'Alpine-3.20'
+                - 'Alpine-3.19'
+                - 'Alpine-3.18'
                 - 'Alpine-3.17'
                 - 'Alpine' (deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
                 - 'Debian-11'

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ inputs:
                 - 'Alpine-3.18'
                 - 'Alpine-3.17'
                 - 'Alpine' (deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)
+                - 'Debian-13'
                 - 'Debian-12'
                 - 'Debian-11'
                 - 'Debian' (deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group = net.kautler
-version = 6.0.1-SNAPSHOT
+version = 6.1.0-SNAPSHOT
 description = A GitHub action to install and setup a Linux distribution for the Windows Subsystem for Linux (WSL)
 
 org.gradle.jvmargs = -Xmx1g

--- a/gradle/build-logic/src/main/kotlin/net/kautler/node.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/net/kautler/node.gradle.kts
@@ -44,8 +44,6 @@ kotlin {
         jsMain {
             dependencies {
                 implementation(libs.kotlinx.coroutines.core)
-                implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.js)
                 implementation(kotlinWrappers.actions.cache)
                 implementation(kotlinWrappers.actions.core)
                 implementation(kotlinWrappers.actions.exec)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ build-node = "20.11.0"
 build-snakeyaml = "2.6"
 kotlin = "2.3.20"
 kotlinx-coroutines = "1.10.2"
-ktor = "3.4.2"
 workflows-kotlin = "2.3.20"
 
 [libraries]
@@ -37,8 +36,6 @@ build-kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-ser
 build-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json" }
 build-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "build-snakeyaml" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 workflows-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "workflows-kotlin" }
 workflows-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "workflows-kotlin" }
 workflows-kotlin-main-kts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "workflows-kotlin" }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -848,11 +848,6 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-ws@8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
-
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"

--- a/readme/README_template.md
+++ b/readme/README_template.md
@@ -153,6 +153,7 @@ The values currently supported by this action are:
 * `Alpine-3.18`
 * `Alpine-3.17`
 * `Alpine` _(deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
+* `Debian-12`
 * `Debian-11`
 * `Debian` **(default)** _(deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
 * `kali-linux`
@@ -195,8 +196,8 @@ https://docs.microsoft.com/en-us/windows/wsl/wsl-config#configuration-settings-f
 This can also be used if the distribution is installed already.
 
 **WARNING:** Setting this option will overwrite any existing content of the file.
-Some distributions like Ubuntu-24.04 might already ship with a wsl.conf file.
-Make sure to check whether a file exists by default and whether you want to included
+Some distributions like Debian-12+ and Ubuntu-24.04+ ship with a default wsl.conf file.
+Make sure to check whether a file exists by default and whether you want to include
 its contents in your configured value.
 
 **Default value:** none

--- a/readme/README_template.md
+++ b/readme/README_template.md
@@ -153,6 +153,7 @@ The values currently supported by this action are:
 * `Alpine-3.18`
 * `Alpine-3.17`
 * `Alpine` _(deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
+* `Debian-13`
 * `Debian-12`
 * `Debian-11`
 * `Debian` **(default)** _(deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_

--- a/readme/README_template.md
+++ b/readme/README_template.md
@@ -145,7 +145,8 @@ so the second that is used will not be installed as the first one will be found 
 WSL distribution ID.
 
 The values currently supported by this action are:
-* `Alpine`
+* `Alpine-3.17`
+* `Alpine` _(deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
 * `Debian-11`
 * `Debian` **(default)** _(deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
 * `kali-linux`

--- a/readme/README_template.md
+++ b/readme/README_template.md
@@ -145,8 +145,9 @@ so the second that is used will not be installed as the first one will be found 
 WSL distribution ID.
 
 The values currently supported by this action are:
-* `Debian` **(default)**
 * `Alpine`
+* `Debian-11`
+* `Debian` **(default)** _(deprecated, 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
 * `kali-linux`
 * `openSUSE-Leap-15.2`
 * `Ubuntu-24.04`

--- a/readme/README_template.md
+++ b/readme/README_template.md
@@ -145,6 +145,12 @@ so the second that is used will not be installed as the first one will be found 
 WSL distribution ID.
 
 The values currently supported by this action are:
+* `Alpine-3.23`
+* `Alpine-3.22`
+* `Alpine-3.21`
+* `Alpine-3.20`
+* `Alpine-3.19`
+* `Alpine-3.18`
 * `Alpine-3.17`
 * `Alpine` _(deprecated, 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name)_
 * `Debian-11`

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -16,22 +16,11 @@
 
 package net.kautler.github.action.setup_wsl
 
-import actions.core.debug
-import actions.core.isDebug
 import actions.exec.ExecOptions
 import actions.exec.exec
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.js.Js
-import io.ktor.client.plugins.UserAgent
-import io.ktor.client.request.forms.submitForm
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.HttpStatusCode.Companion.OK
-import io.ktor.http.parameters
 import js.objects.recordOf
-import kotlinx.coroutines.CoroutineStart.LAZY
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
+import net.kautler.github.action.setup_wsl.InstallMethod.APP_BUNDLE
+import net.kautler.github.action.setup_wsl.InstallMethod.TARBALL
 import org.w3c.dom.url.URL
 import semver.SemVer
 
@@ -48,109 +37,49 @@ val distributions = listOf(
     Ubuntu2404
 ).associateBy { it.userId }
 
+enum class InstallMethod { APP_BUNDLE, TARBALL }
+
 sealed class Distribution(
     val wslId: String,
+    val userId: String,
     val distributionName: String,
     val version: SemVer,
-    private val _downloadUrl: URL?,
-    private val productId: String?,
-    val installerFile: String,
-    val userId: String = wslId
+    val downloadUrl: URL,
+    val installerFile: String? = null
 ) {
-    @DelicateCoroutinesApi
-    val downloadUrl = GlobalScope.async(start = LAZY) {
-        if (_downloadUrl != null) {
-            return@async _downloadUrl
-        }
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String? = null
+    ) : this(wslId, wslId, distributionName, version, downloadUrl, installerFile)
 
-        val parameters = parameters {
-            append("type", "ProductId")
-            append("url", productId!!)
-        }
+    val downloadFileName = downloadUrl
+        .pathname
+        .substringAfterLast('/')
+        .substringBefore('?')
 
-        return@async HttpClient(Js) {
-            install(UserAgent) {
-                agent = "Setup WSL GitHub Action"
-            }
-        }.use { client ->
-            retry(5) {
-                val response = client.submitForm(
-                    url = "https://store.rg-adguard.net/api/GetFiles",
-                    formParameters = parameters
-                )
-
-                if (response.status != OK) {
-                    if (isDebug()) {
-                        val echoResponse = client.submitForm(
-                            url = "https://echo.free.beeceptor.com/api/GetFiles",
-                            formParameters = parameters
-                        )
-                        if (echoResponse.status == OK) {
-                            debug("Request:\n${echoResponse.bodyAsText()}")
-                        } else {
-                            debug("Could not get echo response (statusCode: ${echoResponse.status.value} / statusMessage: ${echoResponse.status.description})")
-                        }
-
-                        val responseMessage = JSON.stringify(
-                            recordOf(
-                                "httpVersion" to "${response.version}",
-                                "headers" to "${response.headers}",
-                                "method" to "${response.call.request.method}",
-                                "url" to "${response.call.request.url}",
-                                "statusCode" to response.status.value,
-                                "statusMessage" to response.status.description,
-                                "body" to response.bodyAsText()
-                            ),
-                            space = 2
-                        )
-                        debug("Response:\n$responseMessage")
-                    }
-                    error("Could not determine download URL (statusCode: ${response.status.value} / statusMessage: ${response.status.description})")
-                }
-
-                val body = response.bodyAsText()
-                val downloadLinkAnchorMatch =
-                    """<a [^>]*href="(?<url>[^"]+)"[^>]*>[^<]*\.appx(?:bundle)?</a>""".toRegex().find(body)
-                        ?: error("Could not determine download URL from:\n$body")
-
-                return@retry URL(downloadLinkAnchorMatch.groups[1]!!.value)
-            }
-        }
+    val installMethod = when {
+        installerFile != null -> APP_BUNDLE
+        downloadFileName.endsWith(".tar.gz") || downloadFileName.endsWith(".tgz") -> TARBALL
+        else -> error("Unknown install method for download URL '$downloadUrl'")
     }
 
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        downloadUrl: URL,
-        installerFile: String
-    ) : this(wslId, distributionName, version, downloadUrl, null, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        downloadUrl: URL,
-        installerFile: String,
-    ) : this(wslId, distributionName, version, downloadUrl, null, installerFile, userId)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : this(wslId, distributionName, version, null, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : this(wslId, distributionName, version, null, productId, installerFile, userId)
+    open suspend fun createUser(username: String) {
+        exec(
+            commandLine = "wsl",
+            args = arrayOf(
+                "--distribution",
+                wslId,
+                "useradd",
+                "-m",
+                "-p",
+                "4qBD5NWD3IkbU",
+                username
+            )
+        )
+    }
 
     abstract suspend fun update()
 
@@ -163,7 +92,7 @@ abstract class AptGetBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, distributionName, version, downloadUrl, installerFile)
 
     constructor(
@@ -172,25 +101,8 @@ abstract class AptGetBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, distributionName, version, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, userId, distributionName, version, productId, installerFile)
 
     protected open suspend fun refresh() {
         exec(
@@ -263,8 +175,6 @@ object Ubuntu2404 : AptGetBasedDistribution(
     wslId = "Ubuntu-24.04",
     distributionName = "Ubuntu",
     version = SemVer("24.4.0"),
-    // work-around for missing shortlink on https://learn.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions
-    //downloadUrl = URL("https://aka.ms/wslubuntu2404"),
     downloadUrl = URL("https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu2404-240425.AppxBundle"),
     installerFile = "ubuntu2404.exe"
 )
@@ -309,7 +219,7 @@ abstract class DebianDistribution : AptGetBasedDistribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, distributionName, version, downloadUrl, installerFile)
 
     constructor(
@@ -318,25 +228,8 @@ abstract class DebianDistribution : AptGetBasedDistribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, distributionName, version, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, userId, distributionName, version, productId, installerFile)
 
     override suspend fun update() {
         refresh()
@@ -352,7 +245,7 @@ abstract class ArchivedDebianDistribution : DebianDistribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, distributionName, version, downloadUrl, installerFile)
 
     constructor(
@@ -361,25 +254,8 @@ abstract class ArchivedDebianDistribution : DebianDistribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, distributionName, version, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, userId, distributionName, version, productId, installerFile)
 
     override suspend fun refresh() {
         exec(
@@ -450,7 +326,7 @@ abstract class ZypperBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, distributionName, version, downloadUrl, installerFile)
 
     constructor(
@@ -459,25 +335,8 @@ abstract class ZypperBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, distributionName, version, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, userId, distributionName, version, productId, installerFile)
 
     protected open suspend fun refresh() {
         exec(
@@ -542,7 +401,7 @@ abstract class ApkBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, distributionName, version, downloadUrl, installerFile)
 
     constructor(
@@ -551,25 +410,8 @@ abstract class ApkBasedDistribution : Distribution {
         distributionName: String,
         version: SemVer,
         downloadUrl: URL,
-        installerFile: String
+        installerFile: String? = null
     ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
-
-    constructor(
-        wslId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, distributionName, version, productId, installerFile)
-
-    constructor(
-        wslId: String,
-        userId: String,
-        distributionName: String,
-        version: SemVer,
-        productId: String,
-        installerFile: String
-    ) : super(wslId, userId, distributionName, version, productId, installerFile)
 
     private suspend fun refresh() {
         exec(
@@ -611,10 +453,43 @@ abstract class ApkBasedDistribution : Distribution {
     }
 }
 
-object Alpine : ApkBasedDistribution(
+abstract class AlpineDistribution : ApkBasedDistribution {
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String? = null
+    ) : super(wslId, distributionName, version, downloadUrl, installerFile)
+
+    constructor(
+        wslId: String,
+        userId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String? = null
+    ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
+
+    override suspend fun createUser(username: String) {
+        // Alpine minirootfs does not include the shadow package, so useradd is not available.
+        // Use BusyBox adduser instead.
+        exec(
+            commandLine = "wsl",
+            args = arrayOf(
+                "--distribution",
+                wslId,
+                "adduser",
+                "-D",
+                username
+            )
+        )
+    }
+}
+
+object Alpine : AlpineDistribution(
     wslId = "Alpine",
     distributionName = "Alpine",
-    version = SemVer("1.0.3"),
-    productId = "9p804crf0395",
-    installerFile = "Alpine.exe"
+    version = SemVer("3.17.10"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.10-x86_64.tar.gz")
 )

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -37,6 +37,7 @@ val distributions = listOf(
     Debian,
     Debian11,
     Debian12,
+    Debian13,
     Kali,
     OpenSuseLeap15_2,
     Ubuntu1604,
@@ -305,6 +306,13 @@ object Debian12 : DebianDistribution(
     distributionName = "Debian",
     version = SemVer("1.20.0"),
     downloadUrl = URL("https://salsa.debian.org/debian/WSL/-/jobs/7130915/artifacts/raw/Debian_WSL_AMD64_v1.20.0.0.wsl")
+)
+
+object Debian13 : DebianDistribution(
+    wslId = "Debian-13",
+    distributionName = "Debian",
+    version = SemVer("1.24.0"),
+    downloadUrl = URL("https://salsa.debian.org/debian/WSL/-/jobs/9229125/artifacts/raw/Debian_WSL_AMD64_v1.24.0.0.wsl")
 )
 
 object Kali : AptGetBasedDistribution(

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -38,6 +38,7 @@ import semver.SemVer
 val distributions = listOf(
     Alpine,
     Debian,
+    Debian11,
     Kali,
     OpenSuseLeap15_2,
     Ubuntu1604,
@@ -302,13 +303,84 @@ object Ubuntu1604 : AptGetBasedDistribution(
     installerFile = "ubuntu1604.exe"
 )
 
-object Debian : AptGetBasedDistribution(
-    wslId = "Debian",
-    distributionName = "Debian",
-    version = SemVer("1.0.0"),
-    downloadUrl = URL("https://aka.ms/wsl-debian-gnulinux"),
-    installerFile = "debian.exe"
-) {
+abstract class DebianDistribution : AptGetBasedDistribution {
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String
+    ) : super(wslId, distributionName, version, downloadUrl, installerFile)
+
+    constructor(
+        wslId: String,
+        userId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String
+    ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
+
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        productId: String,
+        installerFile: String
+    ) : super(wslId, distributionName, version, productId, installerFile)
+
+    constructor(
+        wslId: String,
+        userId: String,
+        distributionName: String,
+        version: SemVer,
+        productId: String,
+        installerFile: String
+    ) : super(wslId, userId, distributionName, version, productId, installerFile)
+
+    override suspend fun update() {
+        refresh()
+        retry(5) {
+            update(false)
+        }
+    }
+}
+
+abstract class ArchivedDebianDistribution : DebianDistribution {
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String
+    ) : super(wslId, distributionName, version, downloadUrl, installerFile)
+
+    constructor(
+        wslId: String,
+        userId: String,
+        distributionName: String,
+        version: SemVer,
+        downloadUrl: URL,
+        installerFile: String
+    ) : super(wslId, userId, distributionName, version, downloadUrl, installerFile)
+
+    constructor(
+        wslId: String,
+        distributionName: String,
+        version: SemVer,
+        productId: String,
+        installerFile: String
+    ) : super(wslId, distributionName, version, productId, installerFile)
+
+    constructor(
+        wslId: String,
+        userId: String,
+        distributionName: String,
+        version: SemVer,
+        productId: String,
+        installerFile: String
+    ) : super(wslId, userId, distributionName, version, productId, installerFile)
+
     override suspend fun refresh() {
         exec(
             commandLine = "wsl",
@@ -323,14 +395,24 @@ object Debian : AptGetBasedDistribution(
         )
         super.refresh()
     }
-
-    override suspend fun update() {
-        refresh()
-        retry(5) {
-            update(false)
-        }
-    }
 }
+
+object Debian : ArchivedDebianDistribution(
+    wslId = "Debian",
+    distributionName = "Debian",
+    version = SemVer("1.0.0"),
+    downloadUrl = URL("https://aka.ms/wsl-debian-gnulinux"),
+    installerFile = "debian.exe"
+)
+
+object Debian11 : ArchivedDebianDistribution(
+    wslId = "Debian",
+    userId = "Debian-11",
+    distributionName = "Debian",
+    version = SemVer("1.0.0"),
+    downloadUrl = URL("https://aka.ms/wsl-debian-gnulinux"),
+    installerFile = "debian.exe"
+)
 
 object Kali : AptGetBasedDistribution(
     wslId = "MyDistribution",

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -26,6 +26,7 @@ import semver.SemVer
 
 val distributions = listOf(
     Alpine,
+    Alpine317,
     Debian,
     Debian11,
     Kali,
@@ -489,6 +490,14 @@ abstract class AlpineDistribution : ApkBasedDistribution {
 
 object Alpine : AlpineDistribution(
     wslId = "Alpine",
+    distributionName = "Alpine",
+    version = SemVer("3.17.10"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.10-x86_64.tar.gz")
+)
+
+object Alpine317 : AlpineDistribution(
+    wslId = "Alpine",
+    userId = "Alpine-3.17",
     distributionName = "Alpine",
     version = SemVer("3.17.10"),
     downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.10-x86_64.tar.gz")

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -27,6 +27,12 @@ import semver.SemVer
 val distributions = listOf(
     Alpine,
     Alpine317,
+    Alpine318,
+    Alpine319,
+    Alpine320,
+    Alpine321,
+    Alpine322,
+    Alpine323,
     Debian,
     Debian11,
     Kali,
@@ -501,4 +507,46 @@ object Alpine317 : AlpineDistribution(
     distributionName = "Alpine",
     version = SemVer("3.17.10"),
     downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.10-x86_64.tar.gz")
+)
+
+object Alpine318 : AlpineDistribution(
+    wslId = "Alpine-3.18",
+    distributionName = "Alpine",
+    version = SemVer("3.18.12"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.12-x86_64.tar.gz")
+)
+
+object Alpine319 : AlpineDistribution(
+    wslId = "Alpine-3.19",
+    distributionName = "Alpine",
+    version = SemVer("3.19.9"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-minirootfs-3.19.9-x86_64.tar.gz")
+)
+
+object Alpine320 : AlpineDistribution(
+    wslId = "Alpine-3.20",
+    distributionName = "Alpine",
+    version = SemVer("3.20.9"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-minirootfs-3.20.9-x86_64.tar.gz"),
+)
+
+object Alpine321 : AlpineDistribution(
+    wslId = "Alpine-3.21",
+    distributionName = "Alpine",
+    version = SemVer("3.21.6"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/x86_64/alpine-minirootfs-3.21.6-x86_64.tar.gz"),
+)
+
+object Alpine322 : AlpineDistribution(
+    wslId = "Alpine-3.22",
+    distributionName = "Alpine",
+    version = SemVer("3.22.3"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/x86_64/alpine-minirootfs-3.22.3-x86_64.tar.gz"),
+)
+
+object Alpine323 : AlpineDistribution(
+    wslId = "Alpine-3.23",
+    distributionName = "Alpine",
+    version = SemVer("3.23.3"),
+    downloadUrl = URL("https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/x86_64/alpine-minirootfs-3.23.3-x86_64.tar.gz"),
 )

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/Distribution.kt
@@ -21,6 +21,7 @@ import actions.exec.exec
 import js.objects.recordOf
 import net.kautler.github.action.setup_wsl.InstallMethod.APP_BUNDLE
 import net.kautler.github.action.setup_wsl.InstallMethod.TARBALL
+import net.kautler.github.action.setup_wsl.InstallMethod.WSL_FILE
 import org.w3c.dom.url.URL
 import semver.SemVer
 
@@ -35,6 +36,7 @@ val distributions = listOf(
     Alpine323,
     Debian,
     Debian11,
+    Debian12,
     Kali,
     OpenSuseLeap15_2,
     Ubuntu1604,
@@ -44,7 +46,7 @@ val distributions = listOf(
     Ubuntu2404
 ).associateBy { it.userId }
 
-enum class InstallMethod { APP_BUNDLE, TARBALL }
+enum class InstallMethod { APP_BUNDLE, TARBALL, WSL_FILE }
 
 sealed class Distribution(
     val wslId: String,
@@ -69,6 +71,7 @@ sealed class Distribution(
 
     val installMethod = when {
         installerFile != null -> APP_BUNDLE
+        downloadFileName.endsWith(".wsl") -> WSL_FILE
         downloadFileName.endsWith(".tar.gz") || downloadFileName.endsWith(".tgz") -> TARBALL
         else -> error("Unknown install method for download URL '$downloadUrl'")
     }
@@ -295,6 +298,13 @@ object Debian11 : ArchivedDebianDistribution(
     version = SemVer("1.0.0"),
     downloadUrl = URL("https://aka.ms/wsl-debian-gnulinux"),
     installerFile = "debian.exe"
+)
+
+object Debian12 : DebianDistribution(
+    wslId = "Debian-12",
+    distributionName = "Debian",
+    version = SemVer("1.20.0"),
+    downloadUrl = URL("https://salsa.debian.org/debian/WSL/-/jobs/7130915/artifacts/raw/Debian_WSL_AMD64_v1.20.0.0.wsl")
 )
 
 object Kali : AptGetBasedDistribution(

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -39,6 +39,7 @@ import actions.io.mkdirP
 import actions.io.mv
 import actions.io.which
 import actions.tool.cache.cacheDir
+import actions.tool.cache.cacheFile
 import actions.tool.cache.downloadTool
 import actions.tool.cache.find
 import kotlinx.coroutines.CoroutineStart.LAZY
@@ -52,6 +53,8 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import net.kautler.github.action.setup_wsl.InstallMethod.APP_BUNDLE
+import net.kautler.github.action.setup_wsl.InstallMethod.TARBALL
 import node.buffer.Buffer
 import node.buffer.BufferEncoding
 import node.buffer.utf16le
@@ -195,30 +198,49 @@ val distributionDirectory = GlobalScope.async(start = LAZY) {
 
     val cacheKey = "2:distributionDirectory_${distribution.distributionName}_${distribution.version}"
 
+    val installerFile = when (distribution.installMethod) {
+        TARBALL -> distribution.downloadFileName
+        APP_BUNDLE -> distribution.installerFile!!
+    }
+
     val restoredKey = if (useCache) restoreCache(arrayOf(cacheDirectory), cacheKey) else null
     if (restoredKey != null) {
-        if (exists(path.join(cacheDirectory, distribution.installerFile))) {
+        if (exists(path.join(cacheDirectory, installerFile))) {
             return@async cacheDirectory
         }
     }
 
-    val distributionDownload = downloadTool("${distribution.downloadUrl()}")
-    var extractedDistributionDirectory = extractZip(distributionDownload)
+    val distributionDownload = downloadTool("${distribution.downloadUrl}")
 
-    if (!exists(path.join(extractedDistributionDirectory, distribution.installerFile))) {
-        extractedDistributionDirectory = readdir(extractedDistributionDirectory)
-            .asFlow()
-            .filter { it.contains("""(?<!_(?:scale-(?:100|125|150|400)|ARM64))\.appx$""".toRegex()) }
-            .map { extractZip(path.join(extractedDistributionDirectory, it)) }
-            .firstOrNull { exists(path.join(it, distribution.installerFile)) }
-            ?: error("'${distribution.installerFile}' not found for distribution '${distribution.userId}'")
+    when (distribution.installMethod) {
+        TARBALL -> {
+            cacheDirectory = cacheFile(
+                distributionDownload,
+                installerFile,
+                distribution.distributionName,
+                "${distribution.version}"
+            )
+        }
+
+        APP_BUNDLE -> {
+            var extractedDistributionDirectory = extractZip(distributionDownload)
+
+            if (!exists(path.join(extractedDistributionDirectory, installerFile))) {
+                extractedDistributionDirectory = readdir(extractedDistributionDirectory)
+                    .asFlow()
+                    .filter { it.contains("""(?<!_(?:scale-(?:100|125|150|400)|ARM64))\.appx$""".toRegex()) }
+                    .map { extractZip(path.join(extractedDistributionDirectory, it)) }
+                    .firstOrNull { exists(path.join(it, installerFile)) }
+                    ?: error("'$installerFile' not found for distribution '${distribution.userId}'")
+            }
+
+            cacheDirectory = cacheDir(
+                extractedDistributionDirectory,
+                distribution.distributionName,
+                "${distribution.version}"
+            )
+        }
     }
-
-    cacheDirectory = cacheDir(
-        extractedDistributionDirectory,
-        distribution.distributionName,
-        "${distribution.version}"
-    )
 
     if (useCache) {
         saveCache(arrayOf(cacheDirectory), cacheKey)
@@ -288,6 +310,8 @@ val wslShellName by lazy {
 }
 
 val wslShellWrapperDirectory = path.join(process.env["RUNNER_TEMP"]!!, "wsl-shell-wrapper")
+
+val wslInstallationsDirectory = path.join(process.env["RUNNER_TEMP"]!!, "wsl")
 
 val wslShellWrapperPath by lazy {
     path.join(wslShellWrapperDirectory, "wsl-$wslShellName.bat")
@@ -418,11 +442,37 @@ suspend fun installDistribution() {
         waitForWslStatusNotContaining("WSL is finishing an upgrade...")
     }
 
-    exec(
-        commandLine = """"${path.join(distributionDirectory(), distribution.installerFile)}"""",
-        args = arrayOf("install", "--root"),
-        options = ExecOptions(input = Buffer.from(""))
+    val installerFile = path.join(
+        distributionDirectory(),
+        when (distribution.installMethod) {
+            TARBALL -> distribution.downloadFileName
+            APP_BUNDLE -> distribution.installerFile!!
+        }
     )
+
+    when (distribution.installMethod) {
+        TARBALL -> {
+            val installLocation = path.join(wslInstallationsDirectory, distribution.wslId)
+            mkdirP(installLocation)
+            exec(
+                commandLine = "wsl",
+                args = arrayOf(
+                    "--import",
+                    distribution.wslId,
+                    installLocation,
+                    installerFile
+                )
+            )
+        }
+
+        APP_BUNDLE -> {
+            exec(
+                commandLine = """"$installerFile"""",
+                args = arrayOf("install", "--root"),
+                options = ExecOptions(input = Buffer.from(""))
+            )
+        }
+    }
 }
 
 suspend fun waitForWslStatusNotContaining(
@@ -487,18 +537,7 @@ suspend fun writeWslShellWrapper() {
             options = ExecOptions(ignoreReturnCode = true)
         ) == 0
         if (!wslShellUserExists) {
-            exec(
-                commandLine = "wsl",
-                args = arrayOf(
-                    "--distribution",
-                    wslId(),
-                    "useradd",
-                    "-m",
-                    "-p",
-                    "4qBD5NWD3IkbU",
-                    wslShellUser
-                )
-            )
+            distribution.createUser(wslShellUser)
         }
     }
 

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import net.kautler.github.action.setup_wsl.InstallMethod.APP_BUNDLE
 import net.kautler.github.action.setup_wsl.InstallMethod.TARBALL
+import net.kautler.github.action.setup_wsl.InstallMethod.WSL_FILE
 import node.buffer.Buffer
 import node.buffer.BufferEncoding
 import node.buffer.utf16le
@@ -124,7 +125,7 @@ val distribution by lazy {
         Debian -> warning(
             """
                 'Debian' distribution is deprecated.
-                Please migrate to a versioned distribution such as 'Debian-11'.
+                Please migrate to a versioned distribution such as 'Debian-12'.
                 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name.
             """.trimIndent()
         )
@@ -207,7 +208,7 @@ val distributionDirectory = GlobalScope.async(start = LAZY) {
     val cacheKey = "2:distributionDirectory_${distribution.distributionName}_${distribution.version}"
 
     val installerFile = when (distribution.installMethod) {
-        TARBALL -> distribution.downloadFileName
+        TARBALL, WSL_FILE -> distribution.downloadFileName
         APP_BUNDLE -> distribution.installerFile!!
     }
 
@@ -221,7 +222,7 @@ val distributionDirectory = GlobalScope.async(start = LAZY) {
     val distributionDownload = downloadTool("${distribution.downloadUrl}")
 
     when (distribution.installMethod) {
-        TARBALL -> {
+        TARBALL, WSL_FILE -> {
             cacheDirectory = cacheFile(
                 distributionDownload,
                 installerFile,
@@ -453,13 +454,28 @@ suspend fun installDistribution() {
     val installerFile = path.join(
         distributionDirectory(),
         when (distribution.installMethod) {
-            TARBALL -> distribution.downloadFileName
+            TARBALL, WSL_FILE -> distribution.downloadFileName
             APP_BUNDLE -> distribution.installerFile!!
         }
     )
 
     when (distribution.installMethod) {
-        TARBALL -> {
+        WSL_FILE if (wslHelp().contains("--from-file")) -> {
+            exec(
+                commandLine = "wsl",
+                args = arrayOf(
+                    "--install",
+                    "--from-file",
+                    installerFile,
+                    // skip the OOBE script that prompts for interactive user creation
+                    "--no-launch",
+                    "--name",
+                    distribution.wslId
+                )
+            )
+        }
+
+        TARBALL, WSL_FILE -> {
             val installLocation = path.join(wslInstallationsDirectory, distribution.wslId)
             mkdirP(installLocation)
             exec(

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -113,6 +113,14 @@ val distribution by lazy {
     val distribution = distributions[distributionId]
 
     when (distribution) {
+        Alpine -> warning(
+            """
+                'Alpine' distribution is deprecated.
+                Please migrate to a versioned distribution such as 'Alpine-3.17'.
+                'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name.
+            """.trimIndent()
+        )
+
         Debian -> warning(
             """
                 'Debian' distribution is deprecated.

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -107,8 +107,21 @@ val wslHelp = GlobalScope.async(start = LAZY) {
 
 val distribution by lazy {
     val distributionId = getInput("distribution", InputOptions(required = true))
+    val distribution = distributions[distributionId]
 
-    return@lazy requireNotNull(distributions[distributionId]) {
+    when (distribution) {
+        Debian -> warning(
+            """
+                'Debian' distribution is deprecated.
+                Please migrate to a versioned distribution such as 'Debian-11'.
+                'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name.
+            """.trimIndent()
+        )
+
+        else -> Unit
+    }
+
+    return@lazy requireNotNull(distribution) {
         "'${distributionId}' is not a valid distribution. Valid values: ${
             distributions.keys.sortedWith(String.CASE_INSENSITIVE_ORDER).joinToString()
         }"

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -125,7 +125,7 @@ val distribution by lazy {
         Debian -> warning(
             """
                 'Debian' distribution is deprecated.
-                Please migrate to a versioned distribution such as 'Debian-12'.
+                Please migrate to a versioned distribution such as 'Debian-13'.
                 'Debian-11' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name.
             """.trimIndent()
         )

--- a/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
+++ b/src/jsMain/kotlin/net/kautler/github/action/setup_wsl/SetupWsl.kt
@@ -116,7 +116,7 @@ val distribution by lazy {
         Alpine -> warning(
             """
                 'Alpine' distribution is deprecated.
-                Please migrate to a versioned distribution such as 'Alpine-3.17'.
+                Please migrate to a versioned distribution such as 'Alpine-3.23'.
                 'Alpine-3.17' is a drop-in replacement, except for the wsl-shell-distribution-wrapper name.
             """.trimIndent()
         )


### PR DESCRIPTION
- Fixes #76
- Fixes #82

## Changes
- Debian
  - Add "Debian-11" (bullseye). "Debian-12" (bookworm) and "Debian-13" (trixie) using .wsl files from Salsa.
  - Deprecate "Debian" (bullseye, stale aka.ms shortlink with broken backports).
  - Default distribution changed to "Debian-11" for backward compatibility.
- Alpine
  - Add "Alpine-3.17" ... "Alpine-3.23" using official minirootfs tarballs.
  - Deprecate the broken "Alpine" (third-party MS Store API permanently blocked) which now points to the last-working Alpine-3.17
- Both new distribution types are installed via `wsl --from-file --no-launch` with fallback to `wsl --import`, instead of the AppxBundle installer.
- Remove dead productId / rg-adguard API code, Ktor
- Make installation method, user creation, and cache filename handling distribution-aware.


This is a breaking change as distributions get major version bumps.
I think it is a good timing to bundle with #84 (Node.js major version bump).